### PR TITLE
Tom/clean timestep

### DIFF
--- a/src/epoch3d.F90
+++ b/src/epoch3d.F90
@@ -117,7 +117,6 @@ PROGRAM pic
 #endif
 
   DO
-    IF ((step >= nsteps .AND. nsteps >= 0) .OR. (time >= t_end)) EXIT
     IF (timer_collect) THEN
       CALL timer_stop(c_timer_step)
       CALL timer_reset
@@ -140,6 +139,8 @@ PROGRAM pic
     time = time + dt
 
     CALL update_eb_fields_final
+
+    IF ((step >= nsteps .AND. nsteps >= 0) .OR. (time >= t_end)) EXIT
 
     CALL output_routines(step)
 

--- a/src/epoch3d.F90
+++ b/src/epoch3d.F90
@@ -104,7 +104,6 @@ PROGRAM pic
   CALL particle_bcs
   CALL efield_bcs
   CALL bfield_final_bcs
-  time = time + dt / 2.0_num
 
   IF (rank == 0) PRINT *, 'Equilibrium set up OK, running code'
 

--- a/src/epoch3d.F90
+++ b/src/epoch3d.F90
@@ -135,14 +135,13 @@ PROGRAM pic
 #ifdef PAT_DEBUG
     CALL pat_mpi_monitor(step,1)
 #endif
-    
+
     step = step + 1
-    time = time + dt / 2.0_num
-    CALL output_routines(step)
-    time = time - dt / 2.0_num
+    time = time + dt
 
     CALL update_eb_fields_final
-    time = time + dt
+
+    CALL output_routines(step)
 
     ! This section ensures that the particle count for the species_list
     ! objects is accurate. This makes some things easier, but increases

--- a/src/epoch3d.F90
+++ b/src/epoch3d.F90
@@ -40,7 +40,7 @@ PROGRAM pic
 #ifdef PAT_DEBUG
   CHARACTER(LEN=17) :: patc_out_fn = "patc_epoch3d.out"//CHAR(0)
 #endif
-  
+
   REAL(num) :: runtime
   TYPE(particle_species), POINTER :: species, next_species
 
@@ -115,7 +115,7 @@ PROGRAM pic
 #ifdef PAT_DEBUG
   CALL pat_mpi_open(patc_out_fn)
 #endif
-  
+
   DO
     IF ((step >= nsteps .AND. nsteps >= 0) .OR. (time >= t_end)) EXIT
     IF (timer_collect) THEN
@@ -125,7 +125,7 @@ PROGRAM pic
     ENDIF
     push = (time >= particle_push_start_time)
     CALL update_eb_fields_half
-    
+
     IF (push) THEN
       ! .FALSE. this time to use load balancing threshold
       IF (use_balance) CALL balance_workload(.FALSE.)
@@ -156,13 +156,13 @@ PROGRAM pic
       species%count_update_step = step
     ENDDO
 #endif
-    
+
   ENDDO
- 
+
 #ifdef PAT_DEBUG
   CALL pat_mpi_close()
 #endif
-  
+
   IF (rank == 0) runtime = MPI_WTIME() - walltime_start
 
   CALL output_routines(step)


### PR DESCRIPTION
Some changes to the timestep structure:

 - Removed the initialisation of time to dt/2. I think this is a relic of the old leapfrog scheme used in EPOCH, before it was rewritten such that variables were only defined at integer time steps.
 - Moved the exit check condition in the main loop to prevent spurious half time-steps being applied before the final output. This fix has been ported from EPOCH v4.18.
 - Moved the output routine call such that the diagnostics are carried out for particle and field data both at integer time levels.

Previously `output_routines` were being called whilst field data was defined at half-integer time-steps, and particle data at integer time-steps. Again this is inherited from core EPOCH. The motivation there is to enable exact restarts. As there's no restarting capability in minepoch, I see no reason to keep it. Indeed, given our only diagnostic is energy, it makes no sense to output that value unless field and particle data is defined at the same time.