### PR TITLE
Tom/basic ci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,6 +46,6 @@ jobs:
       - name: Test-Parallel
         run: |
           cp Data/two_stream.deck Data/input.deck
-          mpirun -np 4 ./bin/epoch3d
+          mpirun -np 2 ./bin/epoch3d
           export PYTHONPATH=$PYTHONPATH:$(pwd)
           python3 minepoch_py/test.py

--- a/minepoch_py/energy.py
+++ b/minepoch_py/energy.py
@@ -42,8 +42,8 @@ def plot_field_energy(fname, xscale=1.0, dbg=False, ylog=False, xlog=False):
     plt.tight_layout()
 
 
-def energy_check(fname='Data/output.dat', check_error=False, tolerance=1e-4,
-                 label=None, plot=True, savefig=False):
+def energy_check(fname='Data/output.dat', tolerance=None, label=None,
+                 plot=True, savefig=False):
     times, pe, fe = get_energies(fname)
     total_energy = pe + fe
 
@@ -61,7 +61,7 @@ def energy_check(fname='Data/output.dat', check_error=False, tolerance=1e-4,
         if savefig:
             plt.savefig('energy_conservation.png')
 
-    if check_error:
+    if tolerance is not None:
         delta_e = np.abs(total_energy[-1] - total_energy[0]) / total_energy[0]
         if delta_e > tolerance:
             print('Energy conservation (fractional) error = %.4E' % delta_e)

--- a/minepoch_py/energy.py
+++ b/minepoch_py/energy.py
@@ -43,7 +43,7 @@ def plot_field_energy(fname, xscale=1.0, dbg=False, ylog=False, xlog=False):
 
 
 def energy_check(fname='Data/output.dat', check_error=False, tolerance=1e-4,
-                 label=None, plot=True):
+                 label=None, plot=True, savefig=False):
     times, pe, fe = get_energies(fname)
     total_energy = pe + fe
 
@@ -57,6 +57,9 @@ def energy_check(fname='Data/output.dat', check_error=False, tolerance=1e-4,
         # Update legend if necessary
         if label is not None:
             plt.legend()
+
+        if savefig:
+            plt.savefig('energy_conservation.png')
 
     if check_error:
         delta_e = np.abs(total_energy[-1] - total_energy[0]) / total_energy[0]

--- a/minepoch_py/test.py
+++ b/minepoch_py/test.py
@@ -4,11 +4,11 @@ from minepoch_py.energy import energy_check
 from minepoch_py.two_stream import two_stream_analysis
 
 
-def run_tests():
+def run_tests(plot=True, savefig=True):
 
-    energy_error = energy_check(check_error=True, plot=False)
+    energy_error = energy_check(check_error=True, plot=plot, savefig=savefig)
 
-    rate, _ = two_stream_analysis(check_growth=True, plot=False)
+    rate, _ = two_stream_analysis(check_growth=True, plot=plot, savefig=savefig)
 
     # Allow 5% error on growth rate
     rate_tolerance = 0.05

--- a/minepoch_py/test.py
+++ b/minepoch_py/test.py
@@ -6,7 +6,7 @@ from minepoch_py.two_stream import two_stream_analysis
 
 def run_tests(plot=True, savefig=True):
 
-    energy_error = energy_check(check_error=True, plot=plot, savefig=savefig)
+    energy_error = energy_check(tolerance=1e-4, plot=plot, savefig=savefig)
 
     rate, _ = two_stream_analysis(check_growth=True, plot=plot, savefig=savefig)
 

--- a/minepoch_py/two_stream.py
+++ b/minepoch_py/two_stream.py
@@ -17,7 +17,7 @@ def two_stream_analysis(fname='Data/output.dat', plot=True, check_growth=True,
         t0 = 0.0
         t1 = 30.0
         plt.plot([t0, t1], [1e-8, 1e-8*np.exp(0.7*t1)], linestyle='--',
-                 color='black')
+                 color='black', label='Theory')
         plt.ylim(top=1e-2)
         plt.gca().yaxis.set_ticks_position('both')
         plt.xlabel(r'$\mathrm{t}\omega_{pe}$', fontsize=16)
@@ -47,10 +47,12 @@ def two_stream_analysis(fname='Data/output.dat', plot=True, check_growth=True,
         if plot:
             # Plot linear fit, shifted slightly vertically
             fit = 5 * np.exp(popt[1]) * np.exp(times_linear * popt[0])
-            plt.plot(times_linear, fit, color='green')
+            plt.plot(times_linear, fit, color='green', label='Observed')
 
-    if (savefig and plot):
-        plt.savefig('two_stream.png')
+    if plot:
+        plt.legend(fontsize=18, loc='upper left')
+        if savefig:
+            plt.savefig('two_stream.png')
 
     if check_growth:
         return popt[0], np.sqrt(np.diag(pcov))[0]

--- a/minepoch_py/two_stream.py
+++ b/minepoch_py/two_stream.py
@@ -17,7 +17,7 @@ def two_stream_analysis(fname='Data/output.dat', plot=True, check_growth=True,
         t0 = 0.0
         t1 = 30.0
         plt.plot([t0, t1], [1e-8, 1e-8*np.exp(0.7*t1)], linestyle='--',
-                 color='black', label='Theory')
+                 color='black', label='Theory (0.70)')
         plt.ylim(top=1e-2)
         plt.gca().yaxis.set_ticks_position('both')
         plt.xlabel(r'$\mathrm{t}\omega_{pe}$', fontsize=16)
@@ -47,10 +47,11 @@ def two_stream_analysis(fname='Data/output.dat', plot=True, check_growth=True,
         if plot:
             # Plot linear fit, shifted slightly vertically
             fit = 5 * np.exp(popt[1]) * np.exp(times_linear * popt[0])
-            plt.plot(times_linear, fit, color='green', label='Observed')
+            plt.plot(times_linear, fit, color='green',
+                     label='Observed (%.4F)' % popt[0])
 
     if plot:
-        plt.legend(fontsize=18, loc='upper left')
+        plt.legend(fontsize=14, loc='upper left')
         if savefig:
             plt.savefig('two_stream.png')
 


### PR DESCRIPTION
Some improvements to CI:

 - Run parallel test on 2 cores. Previous oversubscription was making the tests very slow.
 - run_tests now generates and saves diagnostic plots by default.
 - Add a legend to the two stream plot, including observed and theory growth rates.