### PR TITLE
-Restore specific field initialisation for drift-kinetic solve.

### DIFF
--- a/src/housekeeping/problem_setup.f90
+++ b/src/housekeeping/problem_setup.f90
@@ -116,6 +116,13 @@ CONTAINS
              end do
           end do
        END IF
+    CASE ('drift_kin_default')
+       ex = 0.0_num
+       ey = 0.0_num
+       ez = 0.0_num
+       bx = 0.0_num
+       by = 0.0_num
+       bz = 1.0_num
     CASE default
     END SELECT
   END SUBROUTINE fields_initialise


### PR DESCRIPTION
The drift-kinetic solver requires that the B-field does not have zero strength anywhere. The default field initialisation (used for the example deck) therefore needs to be modified.

With this modification, the drift-kinetic example runs (correctness is not yet tested).