### PR TITLE
Tom/python plots

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,18 +41,18 @@ jobs:
           cp Data/two_stream.deck Data/input.deck
           ./bin/epoch3d
           export PYTHONPATH=$PYTHONPATH:$(pwd)
-          python3 minepoch_py/test.py
+          python3 minepoch_py/test.py --disable_plots
 
       - name: Test-substep
         run: |
           cp Data/two_stream_substep.deck Data/input.deck
           ./bin/epoch3d
           export PYTHONPATH=$PYTHONPATH:$(pwd)
-          python3 minepoch_py/test.py --energy_conservation=0.006
+          python3 minepoch_py/test.py --energy_conservation=0.006 --disable_plots
 
       - name: Test-Parallel
         run: |
           cp Data/two_stream.deck Data/input.deck
           mpirun -np 2 ./bin/epoch3d
           export PYTHONPATH=$PYTHONPATH:$(pwd)
-          python3 minepoch_py/test.py
+          python3 minepoch_py/test.py --disable_plots

--- a/minepoch_py/energy.py
+++ b/minepoch_py/energy.py
@@ -21,14 +21,14 @@ def get_energies(fname):
     return times, particle_energies, field_energies
 
 
-def plot_field_energy(fname, xscale=1.0, dbg=False, ylog=False, xlog=False):
+def plot_field_energy(fname, xscale=1.0, dbg=False, ylog=False, xlog=False, **kwargs):
     # Read energies from file. Ignore particle energy
     times, _, energies = get_energies(fname)
 
     if dbg:
         print(np.max(energies))
 
-    plt.plot(times * xscale, energies)
+    plt.plot(times * xscale, energies, **kwargs)
 
     if ylog:
         plt.yscale('log')

--- a/minepoch_py/energy.py
+++ b/minepoch_py/energy.py
@@ -58,6 +58,8 @@ def energy_check(fname='Data/output.dat', tolerance=None, label=None,
         if label is not None:
             plt.legend()
 
+        plt.tight_layout()
+
         if savefig:
             plt.savefig('energy_conservation.png')
 

--- a/minepoch_py/test.py
+++ b/minepoch_py/test.py
@@ -31,12 +31,17 @@ def parse_arguments():
         nargs="?",
     )
 
+    parser.add_argument("--disable_plots", help="Disable plot generation",
+                        action="store_true")
+
     return parser.parse_args()
 
 
-def run_tests(plot=True, savefig=True):
+def run_tests(savefig=True):
 
     options = parse_arguments()
+
+    plot = not options.disable_plots
 
     energy_error = energy_check(tolerance=options.energy_conservation,
                                 plot=plot, savefig=savefig)

--- a/minepoch_py/test.py
+++ b/minepoch_py/test.py
@@ -25,7 +25,7 @@ def parse_arguments():
 
     group.add_argument(
         "--growth_rate",
-        default=0.05,
+        default=0.06,
         type=float,
         help="Allowed fractional error growth rate",
         nargs="?",

--- a/minepoch_py/two_stream.py
+++ b/minepoch_py/two_stream.py
@@ -46,7 +46,7 @@ def two_stream_analysis(fname='Data/output.dat', plot=True, check_growth=True,
         popt, pcov = curve_fit(curve, times_linear, np.log(energy_linear))
         if plot:
             # Plot linear fit, shifted slightly vertically
-            fit = 5 * np.exp(popt[1]) * np.exp(times_linear * popt[0])
+            fit = 2 * np.exp(popt[1]) * np.exp(times_linear * popt[0])
             plt.plot(times_linear, fit, color='green',
                      label='Observed (%.4F)' % popt[0])
 

--- a/minepoch_py/two_stream.py
+++ b/minepoch_py/two_stream.py
@@ -29,8 +29,9 @@ def two_stream_analysis(fname='Data/output.dat', plot=True, check_growth=True,
         times, _, fe = get_energies(fname)
         # Estimate end of linear growth
         end = np.where(fe > np.max(fe) * 0.99)[0][0]
-        # Ignore first third
-        start = end // 3
+        # Measure growth rate over 10 plasma frequencies
+        start = np.argmin(np.abs(times - times[end] + 10 / omega))
+
         if plot:
             # Show region of interest
             plt.gca().axvspan(times[start] * omega, times[end] * omega,


### PR DESCRIPTION
A number of improvements to the two-stream analysis and plotting routines:

 - Always use the same amount of time to estimate growth rates of two-stream instability.
 - Add control of plot generation in test script. Disable plots for GitHub actions.
 - Fix a number of small issues with plotting.

Previously a significant variation was seen when estimating growth rates for the two stream instability on runs from different numbers of cores:

![Old_Rates](https://user-images.githubusercontent.com/50208076/119375420-b3b33980-bcb2-11eb-9aeb-d5747440e3a7.png)

The window for estimating the growth rate was calculated by taking the time of maximum energy, t_max, and using times between t_max / 3 and t_max. As some runs experience peak field energy at earlier times, this resulted in different sized windows being used. I've changed the script so that it now always uses 10 plasma frequencies worth of time:

![New_Rates](https://user-images.githubusercontent.com/50208076/119375742-14db0d00-bcb3-11eb-95ff-59cca503d51f.png)

Note that in all cases this has resulted in a higher observed growth rate, so I've relaxed the tolerance on the test script. The variance between core counts is significantly reduced.