### PR TITLE
Tom/particle push

### DIFF
--- a/src/particles.F90
+++ b/src/particles.F90
@@ -6,6 +6,10 @@ MODULE particles
 
   IMPLICIT NONE
 
+  PRIVATE
+  PUBLIC :: push_particles, push_particles_2ndstep
+  PUBLIC :: setup_fluid, get_fields_at_point
+
   !Store some pieces of this to speed up the current evaluation.
   TYPE fields_eval_tmps
     REAL(num), DIMENSION(sf_min-1:sf_max+1) :: gx, gy, gz

--- a/src/particles.F90
+++ b/src/particles.F90
@@ -6,24 +6,24 @@ MODULE particles
 
   IMPLICIT NONE
 
-!Store some pieces of this to speed up the current evaluation.
-TYPE fields_eval_tmps
+  !Store some pieces of this to speed up the current evaluation.
+  TYPE fields_eval_tmps
     REAL(num), DIMENSION(sf_min-1:sf_max+1) :: gx, gy, gz
     INTEGER :: cell_x1, cell_y1, cell_z1
- END TYPE fields_eval_tmps
+  END TYPE fields_eval_tmps
 
-! Some numerical factors needed for various particle-fields routines.
-    REAL(num) :: i_yz, i_xz, i_xy ! can't store these as particle steps may vary
-    REAL(num) :: idx, idy, idz
+  ! Some numerical factors needed for various particle-fields routines.
+  REAL(num) :: i_yz, i_xz, i_xy ! can't store these as particle steps may vary
+  REAL(num) :: idx, idy, idz
 
+  ! For now, fluid equations for a single species
+  ! density is mass density, p_fluid is momentum density
+  REAL(num), DIMENSION(:), ALLOCATABLE :: dens_fluid_next, forcet, dens_fluid
+  REAL(num), DIMENSION(:), ALLOCATABLE :: dens_fluid0, p_fluid0
+  REAL(num), DIMENSION(:), ALLOCATABLE :: p_fluid_next, p_fluid, pressuret
+  REAL(num) :: dt_fluid, dx_fluid
+  INTEGER :: nx_fluid
 
-    ! For now, fluid equations for a single species
-    ! density is mass density, p_fluid is momentum density
-    REAL(num), DIMENSION(:), ALLOCATABLE :: dens_fluid_next, forcet, dens_fluid
-    REAL(num), DIMENSION(:), ALLOCATABLE :: dens_fluid0, p_fluid0
-    REAL(num), DIMENSION(:), ALLOCATABLE :: p_fluid_next, p_fluid, pressuret
-    REAL(num) :: dt_fluid, dx_fluid
-    INTEGER :: nx_fluid
 CONTAINS
 
   SUBROUTINE push_particles_2ndstep
@@ -116,7 +116,7 @@ CONTAINS
     REAL(num) :: cmratio, ccmratio
 
     ! Temporary variables
-    REAL(num) :: root, dtfac, gamma, third
+    REAL(num) :: root, dtfac, gamma
     REAL(num) :: delta_x, delta_y, delta_z
     INTEGER(i8) :: ipart
     REAL(num), PARAMETER :: fac = (1.0_num / 24.0_num)**c_ndims
@@ -149,7 +149,6 @@ CONTAINS
     dto2 = dt / 2.0_num
     dtco2 = c * dto2
     dtfac = 0.5_num * dt * fac
-    third = 1.0_num / 3.0_num
 
     i_yz = idy * idz * fac
     i_xz = idx * idz * fac

--- a/src/particles.F90
+++ b/src/particles.F90
@@ -59,6 +59,16 @@ CONTAINS
     INTEGER :: ispecies, isubstep
     TYPE(particle_species), POINTER :: species, next_species
 
+    ! Reset current arrays
+    jx = 0.0_num
+    jy = 0.0_num
+    jz = 0.0_num
+
+    jx_d = 0.0_num
+    jy_d = 0.0_num
+    jz_d = 0.0_num
+
+
     next_species => species_list
     DO ispecies = 1, n_species
        species => next_species
@@ -128,14 +138,6 @@ CONTAINS
     REAL(num) :: idt, dto2, dtco2, idt0, dt_sub
 
     dt_sub = dt / species%nsubstep
-
-    jx = 0.0_num
-    jy = 0.0_num
-    jz = 0.0_num
-
-    jx_d = 0.0_num
-    jy_d = 0.0_num
-    jz_d = 0.0_num
 
     gx = 0.0_num
     gy = 0.0_num

--- a/src/particles.F90
+++ b/src/particles.F90
@@ -13,6 +13,7 @@ MODULE particles
   END TYPE fields_eval_tmps
 
   ! Some numerical factors needed for various particle-fields routines.
+  REAL(num), PARAMETER :: fac = (1.0_num / 24.0_num)**c_ndims
   REAL(num) :: i_yz, i_xz, i_xy ! can't store these as particle steps may vary
   REAL(num) :: idx, idy, idz
 
@@ -58,7 +59,6 @@ CONTAINS
 
     INTEGER :: ispecies, isubstep
     TYPE(particle_species), POINTER :: species, next_species
-    REAL(num), PARAMETER :: fac = (1.0_num / 24.0_num)**c_ndims
 
     ! Reset current arrays
     jx = 0.0_num
@@ -139,7 +139,6 @@ CONTAINS
     REAL(num) :: root, dtfac, gamma
     REAL(num) :: delta_x, delta_y, delta_z
     INTEGER(i8) :: ipart
-    REAL(num), PARAMETER :: fac = (1.0_num / 24.0_num)**c_ndims
     TYPE(particle), POINTER :: current, next
     TYPE(fields_eval_tmps) :: st_half
     REAL(num), DIMENSION(3) :: part_pos_t1p5, pos_half, Bvec, Evec
@@ -509,7 +508,6 @@ CONTAINS
     REAL(num), DIMENSION(sf_min-1:sf_max+1,2) :: gdx, gdy, gdz
     REAL(num), DIMENSION(sf_min-1:sf_max+1,2) :: hdx, hdy, hdz
     REAL(num) :: idx,idy,idz
-    REAL(num), PARAMETER :: fac = (1.0_num / 24.0_num)**c_ndims
 
     INTEGER :: cello_x,cello_y,cello_z
     INTEGER :: xp,yp,zp !Keep track of which derivative is being taken.
@@ -769,7 +767,6 @@ CONTAINS
     TYPE(fields_eval_tmps), INTENT(INOUT) :: st
     REAL(num), DIMENSION(3),   INTENT(INOUT) :: pos,bvec,evec
     REAL(num), DIMENSION(3,3), INTENT(INOUT), OPTIONAL :: btens
-    REAL(num), PARAMETER :: fac = (1.0_num / 24.0_num)**c_ndims
 
     ! Fields at particle location
     REAL(num) :: ex_part, ey_part, ez_part, bx_part, by_part, bz_part

--- a/src/particles.F90
+++ b/src/particles.F90
@@ -58,6 +58,7 @@ CONTAINS
 
     INTEGER :: ispecies, isubstep
     TYPE(particle_species), POINTER :: species, next_species
+    REAL(num), PARAMETER :: fac = (1.0_num / 24.0_num)**c_ndims
 
     ! Reset current arrays
     jx = 0.0_num
@@ -68,6 +69,15 @@ CONTAINS
     jy_d = 0.0_num
     jz_d = 0.0_num
 
+    ! Unvarying multiplication factors
+    idx = 1.0_num / dx
+    idy = 1.0_num / dy
+    idz = 1.0_num / dz
+
+    ! Only used by current deposition
+    i_yz = idy * idz * fac
+    i_xz = idx * idz * fac
+    i_xy = idx * idy * fac
 
     next_species => species_list
     DO ispecies = 1, n_species
@@ -143,18 +153,10 @@ CONTAINS
     gy = 0.0_num
     gz = 0.0_num
 
-    ! Unvarying multiplication factors
-    idx = 1.0_num / dx
-    idy = 1.0_num / dy
-    idz = 1.0_num / dz
     idt = 1.0_num / dt
     dto2 = dt / 2.0_num
     dtco2 = c * dto2
     dtfac = 0.5_num * dt * fac
-
-    i_yz = idy * idz * fac
-    i_xz = idx * idz * fac
-    i_xy = idx * idy * fac
     
     idt = 1.0_num / dt_sub
     idt0 = 1.0_num / dt

--- a/src/particles.F90
+++ b/src/particles.F90
@@ -6,17 +6,17 @@ MODULE particles
 
   IMPLICIT NONE
 
-!Store some pieces of this to speed up the current evaluation.  
+!Store some pieces of this to speed up the current evaluation.
 TYPE fields_eval_tmps
     REAL(num), DIMENSION(sf_min-1:sf_max+1) :: gx, gy, gz
     INTEGER :: cell_x1, cell_y1, cell_z1
  END TYPE fields_eval_tmps
 
-! Some numerical factors needed for various particle-fields routines.  
+! Some numerical factors needed for various particle-fields routines.
     REAL(num) :: i_yz, i_xz, i_xy ! can't store these as particle steps may vary
     REAL(num) :: idx, idy, idz
 
-    
+
     ! For now, fluid equations for a single species
     ! density is mass density, p_fluid is momentum density
     REAL(num), DIMENSION(:), ALLOCATABLE :: dens_fluid_next, forcet, dens_fluid
@@ -33,7 +33,7 @@ CONTAINS
     !Revert current back to half-step values.
     jx = jx - jx_d
     jy = jy - jy_d
-    jz = jz - jz_d   
+    jz = jz - jz_d
 
     next_species => species_list
     DO ispecies = 1, n_species
@@ -45,7 +45,7 @@ CONTAINS
        IF (species%is_driftkinetic) THEN
           CALL push_particles_dk1(species)
        END IF
-       
+
     ENDDO
 
     CALL current_bcs
@@ -56,6 +56,35 @@ CONTAINS
 
   SUBROUTINE push_particles
 
+    INTEGER :: ispecies, isubstep
+    TYPE(particle_species), POINTER :: species, next_species
+
+    next_species => species_list
+    DO ispecies = 1, n_species
+       species => next_species
+       next_species => species%next
+
+       IF (species%immobile) CYCLE
+
+       IF (species%is_driftkinetic) THEN
+          CALL push_particles_dk0(species)
+       ELSE
+          DO isubstep=1,species%nsubstep
+             CALL push_particles_lorentz_split(species)
+          END DO
+       END IF
+
+    ENDDO
+
+    CALL current_bcs
+    CALL particle_bcs
+
+  END SUBROUTINE push_particles
+
+
+
+  SUBROUTINE push_particles_lorentz_split(species)
+    TYPE(particle_species), INTENT(INOUT) :: species
     ! 2nd order accurate particle pusher using parabolic weighting
     ! on and off the grid. The calculation of J looks rather odd
     ! Since it works by solving d(rho)/dt = div(J) and doing a 1st order
@@ -87,15 +116,18 @@ CONTAINS
     REAL(num) :: cmratio, ccmratio
 
     ! Temporary variables
-    REAL(num) :: idt, dto2, dtco2
     REAL(num) :: root, dtfac, gamma, third
     REAL(num) :: delta_x, delta_y, delta_z
-    INTEGER :: ispecies
     INTEGER(i8) :: ipart
     REAL(num), PARAMETER :: fac = (1.0_num / 24.0_num)**c_ndims
-    INTEGER :: isubstep
     TYPE(particle), POINTER :: current, next
-    TYPE(particle_species), POINTER :: species, next_species
+    TYPE(fields_eval_tmps) :: st_half
+    REAL(num), DIMENSION(3) :: part_pos_t1p5, pos_half, Bvec, Evec
+    REAL(num) :: weight_back, part_qfac
+    REAL(num), DIMENSION(3) :: force, part_v
+    REAL(num) :: idt, dto2, dtco2, idt0, dt_sub
+
+    dt_sub = dt / species%nsubstep
 
     jx = 0.0_num
     jy = 0.0_num
@@ -110,7 +142,6 @@ CONTAINS
     gz = 0.0_num
 
     ! Unvarying multiplication factors
-
     idx = 1.0_num / dx
     idy = 1.0_num / dy
     idz = 1.0_num / dz
@@ -123,165 +154,134 @@ CONTAINS
     i_yz = idy * idz * fac
     i_xz = idx * idz * fac
     i_xy = idx * idy * fac
-
-    next_species => species_list
-    DO ispecies = 1, n_species
-       species => next_species
-       next_species => species%next
-
-       IF (species%immobile) CYCLE
-
-       IF (species%is_driftkinetic) THEN
-          CALL push_particles_dk0(species)
-       ELSE
-          DO isubstep=1,species%nsubstep
-             CALL push_particles_lorentz_split(dt/species%nsubstep)
-          END DO
-       END IF
-
-    ENDDO
-
-    CALL current_bcs
-    CALL particle_bcs
     
-  contains
+    idt = 1.0_num / dt_sub
+    idt0 = 1.0_num / dt
+    dto2 = dt_sub / 2.0_num
+    dtco2 = c * dto2
+    dtfac = 0.5_num * dt_sub * fac
 
-    SUBROUTINE push_particles_lorentz_split(dt_sub)
-      REAL(num), intent(IN) :: dt_sub 
-      TYPE(fields_eval_tmps) :: st_half
-      REAL(num), DIMENSION(3) :: part_pos_t1p5, pos_half, Bvec, Evec
-      REAL(num) :: weight_back, part_qfac
-      REAL(num), DIMENSION(3) :: force, part_v
-      REAL(num) :: idt, dto2, dtco2, idt0
-      REAL(num) :: dtfac
-      
-      idt = 1.0_num / dt_sub
-      idt0= 1.0_num / dt
-      dto2 = dt_sub / 2.0_num
-      dtco2 = c * dto2
-      dtfac = 0.5_num * dt_sub * fac
+    IF (species%solve_fluid) CALL initstep_fluid
 
-      IF (species%solve_fluid) CALL initstep_fluid
-      
-      current => species%attached_list%head
+    current => species%attached_list%head
 
-      IF (.NOT. particles_uniformly_distributed) THEN
-         part_weight = species%weight 
-      ENDIF
+    IF (.NOT. particles_uniformly_distributed) THEN
+      part_weight = species%weight
+    END IF
 
-      !DEC$ VECTOR ALWAYS
-      DO ipart = 1, species%attached_list%count
-         next => current%next
-         IF (particles_uniformly_distributed) THEN
-            part_weight = current%weight
-         ENDIF
+    !DEC$ VECTOR ALWAYS
+    DO ipart = 1, species%attached_list%count
+      next => current%next
+      IF (particles_uniformly_distributed) THEN
+        part_weight = current%weight
+      END IF
 
-         part_q    = current%charge
-         part_qfac = part_q * idt0
-         part_mc  = c * current%mass
-         ipart_mc = 1.0_num / part_mc
-         cmratio  = part_q * dtfac * ipart_mc
-         ccmratio = c * cmratio
+      part_q    = current%charge
+      part_qfac = part_q * idt0
+      part_mc  = c * current%mass
+      ipart_mc = 1.0_num / part_mc
+      cmratio  = part_q * dtfac * ipart_mc
+      ccmratio = c * cmratio
 
-         ! Copy the particle properties out for speed
-         part_ux = current%part_p(1) * ipart_mc
-         part_uy = current%part_p(2) * ipart_mc
-         part_uz = current%part_p(3) * ipart_mc
+      ! Copy the particle properties out for speed
+      part_ux = current%part_p(1) * ipart_mc
+      part_uy = current%part_p(2) * ipart_mc
+      part_uz = current%part_p(3) * ipart_mc
 
-         ! Calculate v(t) from p(t)
-         ! See PSC manual page (25-27)
-         root = dtco2 / SQRT(part_ux**2 + part_uy**2 + part_uz**2 + 1.0_num)
+      ! Calculate v(t) from p(t)
+      ! See PSC manual page (25-27)
+      root = dtco2 / SQRT(part_ux**2 + part_uy**2 + part_uz**2 + 1.0_num)
 
-         ! Move particles to half timestep position to first order
-         pos_half = current%part_pos + root * (/ part_ux, part_uy, part_uz /)
-         CALL get_fields_at_point_store(pos_half,Bvec,Evec,st_half)
+      ! Move particles to half timestep position to first order
+      pos_half = current%part_pos + root * (/ part_ux, part_uy, part_uz /)
+      CALL get_fields_at_point_store(pos_half,Bvec,Evec,st_half)
 
-         ! update particle momenta using weighted fields
-         uxm = part_ux + cmratio * Evec(1)
-         uym = part_uy + cmratio * Evec(2)
-         uzm = part_uz + cmratio * Evec(3)
+      ! update particle momenta using weighted fields
+      uxm = part_ux + cmratio * Evec(1)
+      uym = part_uy + cmratio * Evec(2)
+      uzm = part_uz + cmratio * Evec(3)
 
-         ! Half timestep, then use Boris1970 rotation, see Birdsall and Langdon
-         root = ccmratio / SQRT(uxm**2 + uym**2 + uzm**2 + 1.0_num)
+      ! Half timestep, then use Boris1970 rotation, see Birdsall and Langdon
+      root = ccmratio / SQRT(uxm**2 + uym**2 + uzm**2 + 1.0_num)
 
-         taux = Bvec(1) * root
-         tauy = Bvec(2) * root
-         tauz = Bvec(3) * root
+      taux = Bvec(1) * root
+      tauy = Bvec(2) * root
+      tauz = Bvec(3) * root
 
-         taux2 = taux**2
-         tauy2 = tauy**2
-         tauz2 = tauz**2
+      taux2 = taux**2
+      tauy2 = tauy**2
+      tauz2 = tauz**2
 
-         tau = 1.0_num / (1.0_num + taux2 + tauy2 + tauz2)
+      tau = 1.0_num / (1.0_num + taux2 + tauy2 + tauz2)
 
-         uxp = ((1.0_num + taux2 - tauy2 - tauz2) * uxm &
-              + 2.0_num * ((taux * tauy + tauz) * uym &
-              + (taux * tauz - tauy) * uzm)) * tau
-         uyp = ((1.0_num - taux2 + tauy2 - tauz2) * uym &
-              + 2.0_num * ((tauy * tauz + taux) * uzm &
-              + (tauy * taux - tauz) * uxm)) * tau
-         uzp = ((1.0_num - taux2 - tauy2 + tauz2) * uzm &
-              + 2.0_num * ((tauz * taux + tauy) * uxm &
-              + (tauz * tauy - taux) * uym)) * tau
+      uxp = ((1.0_num + taux2 - tauy2 - tauz2) * uxm &
+          + 2.0_num * ((taux * tauy + tauz) * uym &
+          + (taux * tauz - tauy) * uzm)) * tau
+      uyp = ((1.0_num - taux2 + tauy2 - tauz2) * uym &
+           + 2.0_num * ((tauy * tauz + taux) * uzm &
+           + (tauy * taux - tauz) * uxm)) * tau
+      uzp = ((1.0_num - taux2 - tauy2 + tauz2) * uzm &
+          + 2.0_num * ((tauz * taux + tauy) * uxm &
+          + (tauz * tauy - taux) * uym)) * tau
 
-         ! Rotation over, go to full timestep
-         part_ux = uxp + cmratio * Evec(1)
-         part_uy = uyp + cmratio * Evec(2)
-         part_uz = uzp + cmratio * Evec(3)
+      ! Rotation over, go to full timestep
+      part_ux = uxp + cmratio * Evec(1)
+      part_uy = uyp + cmratio * Evec(2)
+      part_uz = uzp + cmratio * Evec(3)
 
-         ! Calculate particle velocity from particle momentum
-         gamma = SQRT(part_ux**2 + part_uy**2 + part_uz**2 + 1.0_num)
-         root = dtco2 / gamma
+      ! Calculate particle velocity from particle momentum
+      gamma = SQRT(part_ux**2 + part_uy**2 + part_uz**2 + 1.0_num)
+      root = dtco2 / gamma
 
-         delta_x = part_ux * root
-         delta_y = part_uy * root
-         delta_z = part_uz * root
+      delta_x = part_ux * root
+      delta_y = part_uy * root
+      delta_z = part_uz * root
 
-         ! Move particles to end of time step at 2nd order accuracy
-         ! particle has now finished move to end of timestep, place data
-         ! in particle array
-         current%part_pos = pos_half + (/delta_x, delta_y, delta_z/)
-         current%part_p   = part_mc * (/ part_ux, part_uy, part_uz /)
+      ! Move particles to end of time step at 2nd order accuracy
+      ! particle has now finished move to end of timestep, place data
+      ! in particle array
+      current%part_pos = pos_half + (/delta_x, delta_y, delta_z/)
+      current%part_p   = part_mc * (/ part_ux, part_uy, part_uz /)
 
-         ! Delta-f calcuation: subtract background from
-         ! calculated current.
-         IF(species%use_deltaf) THEN
-            weight_back = current%pvol * f0(species, current, current%mass)
-         END IF
-            
-         ! Now advance to t+1.5dt to calculate current. This is detailed in
-         ! the manual between pages 37 and 41. The version coded up looks
-         ! completely different to that in the manual, but is equivalent.
-         ! Use t+1.5 dt so that can update J to t+dt at 2nd order
-         part_pos_t1p5 = current%part_pos + (/ delta_x, delta_y, delta_z /)
-         !Current deposition uses position at t+0.5dt and t+1.5dt, particle
-         !assumed to travel in direct line between these locations. Second order 
-         !in time for evaluation of current at t+dt 
-         CALL current_deposition_store(st_half,part_pos_t1p5,(part_weight*part_qfac),.false.)
+      ! Delta-f calcuation: subtract background from
+      ! calculated current.
+      IF(species%use_deltaf) THEN
+        weight_back = current%pvol * f0(species, current, current%mass)
+      END IF
 
-         if (species%solve_fluid) then
-            part_v = (/part_ux, part_uy,part_uz/)
-            force = part_q*(Evec+cross(part_v,Bvec))
-            CALL assignweight_fluid(current%part_pos, &
-                 & (part_weight-weight_back)*current%part_p(1), &
-                 & (part_weight-weight_back)*current%mass,force )
-         end if
-         
-         current => next
-      ENDDO
+      ! Now advance to t+1.5dt to calculate current. This is detailed in
+      ! the manual between pages 37 and 41. The version coded up looks
+      ! completely different to that in the manual, but is equivalent.
+      ! Use t+1.5 dt so that can update J to t+dt at 2nd order
+      part_pos_t1p5 = current%part_pos + (/ delta_x, delta_y, delta_z /)
+      ! Current deposition uses position at t+0.5dt and t+1.5dt, particle
+      ! assumed to travel in direct line between these locations. Second order
+      ! in time for evaluation of current at t+dt
+      CALL current_deposition_store(st_half,part_pos_t1p5,(part_weight*part_qfac),.false.)
 
-      IF (species%solve_fluid) then
-         CALL fluideq_diag
-         CALL update_fluideq
-      end if
-      
-    END SUBROUTINE push_particles_lorentz_split
+      IF (species%solve_fluid) THEN
+        part_v = (/part_ux, part_uy,part_uz/)
+        force = part_q*(Evec+cross(part_v,Bvec))
+        CALL assignweight_fluid(current%part_pos, &
+            & (part_weight-weight_back)*current%part_p(1), &
+            & (part_weight-weight_back)*current%mass,force )
+      END IF
 
-  END SUBROUTINE push_particles
+      current => next
+    END DO
 
-    !Drift-kinetic push. Because we can't do leapfrog, do an explicit two-step scheme.
-    ! -first substep is just Euler.
-    ! -particles stored at half-timestep to make current update easier.
+    IF (species%solve_fluid) then
+      CALL fluideq_diag
+      CALL update_fluideq
+   END IF
+
+ END SUBROUTINE push_particles_lorentz_split
+
+
+
+ ! Drift-kinetic push. Because we can't do leapfrog, do an explicit two-step scheme.
+ ! -first substep is just Euler.
+ ! -particles stored at half-timestep to make current update easier.
   SUBROUTINE push_particles_dk0(species)
       TYPE(fields_eval_tmps) :: st_0
       TYPE(particle_species), INTENT(INOUT) :: species
@@ -298,7 +298,6 @@ CONTAINS
       INTEGER(i8) :: ipart
       REAL(num) :: idt
       idt = 1.0_num/dt
-
 
       current => species%attached_list%head
 
@@ -328,7 +327,7 @@ CONTAINS
               &  drifts_mu,drifts_vpll, bdotBmag)
 
          dRdt = bdir * part_u
-         dudt = - (part_mu * bdotBmag / current%mass) 
+         dudt = - (part_mu * bdotBmag / current%mass)
          ! Move particles to half timestep position to first order
          pos_0 = current%part_pos + dRdt * dt
          part_u_0 = part_u + dudt * dt
@@ -344,10 +343,10 @@ CONTAINS
          !this is the lowest order current.
          CALL current_deposition_store(st_0,pos_0,(part_weight*part_qfac),.true.)
 
-         
+
          current => next
       ENDDO
-      
+
     END SUBROUTINE push_particles_dk0
 
     !Drift-kinetic push. Because we can't do leapfrog, do an explicit two-step scheme.
@@ -368,7 +367,7 @@ CONTAINS
       INTEGER(i8) :: ipart
       REAL(num) :: idt
       idt = 1.0_num/dt
-      
+
       current => species%attached_list%head
 
       IF (.NOT. particles_uniformly_distributed) THEN
@@ -387,25 +386,25 @@ CONTAINS
          ! Do nonrelativistic drift-kinetics for the moment.
          part_u   = current%part_p(1)
          part_mu  = current%part_p(2)
- 
+
          !Half step position.
          pos_h = current%work(1:3)
          part_u_h = current%work(4)
 
          pos_0 = current%part_pos
-         ! From this point on: need to advance fields half a step in time: we could do this 
+         ! From this point on: need to advance fields half a step in time: we could do this
          ! using the PIC particle currents + estimated drift currents:
 
          CALL get_fields_at_point_store(pos_h,Bvec,Evec,st_half,Btens)
          CALL get_drifts(pos_h,Evec,Bvec,Btens,drifts_ExB,bdir, &
               &  drifts_mu,drifts_vpll, bdotBmag)
          dRdt_1 = bdir * part_u_h
-         dudt_1 = - (part_mu * bdotBmag / current%mass) 
-         
+         dudt_1 = - (part_mu * bdotBmag / current%mass)
+
          ! particle has now finished move to end of timestep, so copy back
          ! into particle array
          part_u = part_u + dudt_1 * dt
-         current%part_pos = current%part_pos + dRdt_1 * dt 
+         current%part_pos = current%part_pos + dRdt_1 * dt
          current%part_p(1:2)   = (/ part_u, part_mu /)
 
          !This is the current between step N+1/2 and N+3/2 so 2nd order at N+1
@@ -417,12 +416,12 @@ CONTAINS
     END SUBROUTINE push_particles_dk1
 
 
-  SUBROUTINE get_drifts(pos,Evec,Bvec,Btens,ExB,bdir,drifts_mu,drifts_vpll,bdir_dotgradBmag)    
+  SUBROUTINE get_drifts(pos,Evec,Bvec,Btens,ExB,bdir,drifts_mu,drifts_vpll,bdir_dotgradBmag)
     REAL(num), DIMENSION(3), INTENT(INOUT) :: pos, ExB, Evec, Bvec
     REAL(num), DIMENSION(3,3), INTENT(INOUT) :: Btens
-    REAL(num), DIMENSION(3), INTENT(OUT)   :: & 
+    REAL(num), DIMENSION(3), INTENT(OUT)   :: &
          & drifts_mu,drifts_vpll
-    REAL(num), INTENT(OUT)   :: bdir_dotgradBmag 
+    REAL(num), INTENT(OUT)   :: bdir_dotgradBmag
 
     REAL(num), DIMENSION(3) :: Bdir,BdotgradB,gradBmag
     REAL(num) :: Bsq,Bnorm
@@ -432,7 +431,7 @@ CONTAINS
     bdir = Bvec/Bnorm
 
     !Maybe can do these with matmul?
-    gradBmag = (Btens(:,1)*Bvec(1) + Btens(:,2)*Bvec(2) + Btens(:,3)*Bvec(3))/Bnorm 
+    gradBmag = (Btens(:,1)*Bvec(1) + Btens(:,2)*Bvec(2) + Btens(:,3)*Bvec(3))/Bnorm
     BdotgradB = Bvec(1)*Btens(1,:) + Bvec(2)*Btens(2,:) + Bvec(3)*Btens(3,:)
 
     bdir_dotgradBmag = dot_product(bdir,gradBmag)
@@ -467,10 +466,10 @@ CONTAINS
     array = 0.0_num
     array(offset-2,2) =  4.0_num*(0.5_num + cell_frac)**3
     array(offset-1,2) =  11.0_num &
-         + 4.0_num * cell_frac * (3.0_num - 3.0_num*cell_frac - 4.0_num*cf2) 
-    array(offset  ,2) =     6.0_num * (4.0_num*cell_frac) * (cf2 - 1.25_num) 
+         + 4.0_num * cell_frac * (3.0_num - 3.0_num*cell_frac - 4.0_num*cf2)
+    array(offset  ,2) =     6.0_num * (4.0_num*cell_frac) * (cf2 - 1.25_num)
     array(offset+1,2) = -11.0_num &
-         + 4.0_num * cell_frac * (3.0_num + 3.0_num*cell_frac - 4.0_num*cf2) 
+         + 4.0_num * cell_frac * (3.0_num + 3.0_num*cell_frac - 4.0_num*cf2)
     array(offset+2,2) = -4.0_num*(0.5_num - cell_frac)**3
 
     !Because cell_frac is negatively proportional to position.
@@ -479,7 +478,7 @@ CONTAINS
   END SUBROUTINE h_derivs
 
   !Rewrite finite-difference evaluation include file as a function for
-  !testing purposes. 
+  !testing purposes.
   SUBROUTINE hfun(array,offset,cell_frac)
     REAL(num), DIMENSION(sf_min-1:sf_max+1), INTENT(INOUT) :: array
     REAL(num), INTENT(IN) :: cell_frac
@@ -552,7 +551,7 @@ CONTAINS
     REAL(num), DIMENSION(3), INTENT(INOUT) :: pos0,pos1
     REAL(num), INTENT(IN) :: chargeweight
     LOGICAL, INTENT(IN) :: drift_switch
-    
+
     TYPE(fields_eval_tmps)  :: st0
 
     CALL calc_stdata(pos0,st0)
@@ -597,7 +596,7 @@ CONTAINS
     REAL(num) :: wx, wy, wz
     REAL(num), PARAMETER :: third=(1.0_num / 3.0_num)
     REAL(num) :: xfac1, xfac2, yfac1, yfac2, zfac1, zfac2
-  
+
 
     part_x = pos(1) - x_grid_min_local
     part_y = pos(2) - y_grid_min_local
@@ -614,7 +613,7 @@ CONTAINS
     cell_y3 = FLOOR(cell_y_r + 0.5_num)
     cell_frac_y = REAL(cell_y3, num) - cell_y_r
     cell_y3 = cell_y3 + 1
-    
+
     cell_z3 = FLOOR(cell_z_r + 0.5_num)
     cell_frac_z = REAL(cell_z3, num) - cell_z_r
     cell_z3 = cell_z3 + 1
@@ -640,48 +639,48 @@ CONTAINS
 
     xmin = sf_min + (dcellx - 1) / 2
     xmax = sf_max + (dcellx + 1) / 2
-    
+
     ymin = sf_min + (dcelly - 1) / 2
     ymax = sf_max + (dcelly + 1) / 2
-    
+
     zmin = sf_min + (dcellz - 1) / 2
     zmax = sf_max + (dcellz + 1) / 2
 
     fjx = i_yz * chargeweight
     fjy = i_xz * chargeweight
     fjz = i_xy * chargeweight
-    
+
     jzh = 0.0_num
     DO iz = zmin, zmax
        cz = st%cell_z1 + iz
        zfac1 =         st%gz(iz) + 0.5_num * hz(iz)
        zfac2 = third * hz(iz) + 0.5_num * st%gz(iz)
-       
+
        gz_iz = st%gz(iz)
        hz_iz = hz(iz)
-       
+
        jyh = 0.0_num
        DO iy = ymin, ymax
           cy = st%cell_y1 + iy
           yfac1 =         st%gy(iy) + 0.5_num * hy(iy)
           yfac2 = third * hy(iy) + 0.5_num * st%gy(iy)
-          
+
           hygz = hy(iy) * gz_iz
           hyhz = hy(iy) * hz_iz
           yzfac = st%gy(iy) * zfac1 + hy(iy) * zfac2
           hzyfac1 = hz_iz * yfac1
           hzyfac2 = hz_iz * yfac2
-          
+
           jxh = 0.0_num
           DO ix = xmin, xmax
              cx = st%cell_x1 + ix
              xfac1 =         st%gx(ix) + 0.5_num * hx(ix)
              xfac2 = third * hx(ix) + 0.5_num * st%gx(ix)
-             
+
              wx = hx(ix) * yzfac
              wy = xfac1 * hygz + xfac2 * hyhz
              wz = st%gx(ix) * hzyfac1 + hx(ix) * hzyfac2
-             
+
              ! This is the bit that actually solves d(rho)/dt = -div(J)
              jxh = jxh - fjx * wx
              jyh(ix) = jyh(ix) - fjy * wy
@@ -690,7 +689,7 @@ CONTAINS
                 jx(cx, cy, cz) = jx(cx, cy, cz) + jxh
                 jy(cx, cy, cz) = jy(cx, cy, cz) + jyh(ix)
                 jz(cx, cy, cz) = jz(cx, cy, cz) + jzh(ix, iy)
-             else 
+             else
                 jx_d(cx, cy, cz) = jx_d(cx, cy, cz) + jxh
                 jy_d(cx, cy, cz) = jy_d(cx, cy, cz) + jyh(ix)
                 jz_d(cx, cy, cz) = jz_d(cx, cy, cz) + jzh(ix, iy)
@@ -706,7 +705,7 @@ CONTAINS
     TYPE(fields_eval_tmps) :: st
     CALL get_fields_at_point_store(pos,bvec,evec,st,btens)
   END SUBROUTINE get_fields_at_point
- 
+
   ! Utility routine for calculating cell offsets and weights
   ! at a position.
   SUBROUTINE calc_stdata(pos,st)
@@ -758,7 +757,7 @@ CONTAINS
 
     st%cell_x1 = cell_x1
     st%cell_y1 = cell_y1
-    st%cell_z1 = cell_z1    
+    st%cell_z1 = cell_z1
   END SUBROUTINE calc_stdata
 
 
@@ -870,14 +869,14 @@ CONTAINS
 
      st%cell_x1 = cell_x1
      st%cell_y1 = cell_y1
-     st%cell_z1 = cell_z1    
-     
+     st%cell_z1 = cell_z1
+
      IF(present(Btens)) THEN
        CALL h_derivs(hdx,hx,dcellx,cell_frac_x,idx)
        CALL h_derivs(hdy,hy,dcelly,cell_frac_y,idy)
        CALL h_derivs(hdz,hz,dcellz,cell_frac_z,idz)
        CALL calc_Btens(Btens,hdx,hdy,hdz,gdx,gdy,gdz,idx,idy,idz, &
-            & cell_x1,cell_x2,cell_y1,cell_y2,cell_z1,cell_z2)  
+            & cell_x1,cell_x2,cell_y1,cell_y2,cell_z1,cell_z2)
      END IF
    END SUBROUTINE get_fields_at_point_store
 
@@ -885,9 +884,9 @@ CONTAINS
     REAL(num), DIMENSION(3)   :: pos,bvec,evec
     REAL(num), DIMENSION(3,3) :: btens
     REAL(num), DIMENSION(3)   ::  drifts_mu,drifts_vpll,ExB,bdir
-    REAL(num)                 :: bdir_dotgradBmag 
+    REAL(num)                 :: bdir_dotgradBmag
 
-    INTEGER :: i,j 
+    INTEGER :: i,j
 
     WRITE (*,*) 'xminmax',x_grid_min_local, x_grid_max_local
     pos(1) =  x_grid_min_local
@@ -911,12 +910,12 @@ CONTAINS
        pos(1) =  x_grid_min_local + i*dx*0.2
        CALL  get_fields_at_point(pos,bvec,evec,btens)
        WRITE (24,*) pos(1),bvec(1),bvec(2),bvec(3),evec(1),evec(2),evec(3)
-       CALL  get_drifts(pos,Evec,Bvec,Btens,ExB,bdir,drifts_mu,drifts_vpll,bdir_dotgradBmag)    
+       CALL  get_drifts(pos,Evec,Bvec,Btens,ExB,bdir,drifts_mu,drifts_vpll,bdir_dotgradBmag)
        !WRITE (24,*) pos(1),bvec(1),bvec(2),bvec(3),btens(1,1),btens(1,2),btens(1,3)
        WRITE (25,*) pos(1),ExB(1),ExB(2),ExB(3),drifts_mu(1),drifts_mu(2),drifts_mu(3)
     END DO
     !CALL MPI_EXIT()
-    STOP  
+    STOP
   END SUBROUTINE postsetup_testing
 
   ! Background distribution function used for delta-f calculations.
@@ -932,7 +931,7 @@ CONTAINS
     REAL(num) :: f0_exponent, norm, two_kb_mass, two_pi_kb_mass3
     REAL(num), DIMENSION(3) :: tl, dl
     TYPE(particle_species),  INTENT(INOUT) :: species
-    
+
     IF (species%use_deltaf) THEN
        two_kb_mass = 2.0_num * kb * mass
        two_pi_kb_mass3 = (pi * two_kb_mass)**3
@@ -948,7 +947,7 @@ CONTAINS
        ! Per-particle momentum
        dl = current%mass*dl/density
        density = density/current%mass
-       
+
        !WRITE (*,*) current%part_p(1), dl(1)
   !     f0_exponent = ((current%part_p(1) - dl(1))**2 / tl(1) &
   !                  + (current%part_p(2) - dl(2))**2 / tl(2) &
@@ -970,7 +969,7 @@ CONTAINS
     REAL(num) :: density
     INTEGER :: ix,ixp,ix0
     REAL(num) :: x,cell_x,xsc
-    
+
     x = r(1)
     xsc = x/dx_fluid
     ix0=floor(xsc)
@@ -984,7 +983,7 @@ CONTAINS
     mom(1)  = (1-cell_x)*p_fluid(ix)    + cell_x*p_fluid(ixp)
 
   END SUBROUTINE fluid_quants
-  
+
   !Piecewise linear evaluation of density.
   REAL(num) FUNCTION density_fluid(r)
     REAL(num), DIMENSION(3) :: r
@@ -996,7 +995,7 @@ CONTAINS
     ix =modulo(ix-1,nx_fluid)+1
     ixp = ix+1
     ixp = modulo(ixp-1,nx_fluid)+1
-    
+
     cell_x = x - ix*dx_fluid
 
     density_fluid = (1-cell_x)*dens_fluid(ix) + cell_x*dens_fluid(ixp)
@@ -1008,34 +1007,34 @@ CONTAINS
   SUBROUTINE assignweight_fluid(r,px,weight,mforce)
     REAL(num), DIMENSION(:), INTENT(INOUT) :: r,mforce
     REAL(num), INTENT(IN)                  :: px,weight
-    
+
     INTEGER :: ix,ixp,ix0
     REAL(num) :: x,cell_x,weight_dV,xsc,dydz
 
     dydz = (z_max-z_min)*(y_max-y_min)
-    
+
     x = r(1)
     xsc = x/dx_fluid
     ix0=floor(xsc)
     ix =modulo(ix0-1,nx_fluid)+1
     ixp = ix+1
     ixp = modulo(ixp-1,nx_fluid)+1
-    
+
     cell_x = xsc - ix0
 
     weight_dV = 1.0/(dx_fluid*dydz)
-    
+
     dens_fluid0(ixp) = dens_fluid0(ixp)  + cell_x*weight*weight_dV
     dens_fluid0(ix)  = dens_fluid0(ix) + (1.0_num-cell_x)*weight*weight_dV
     !dens_fluid0(ix)  = dens_fluid0(ix) + weight_dx
-    
+
     p_fluid0(ixp)= p_fluid0(ixp) + px*cell_x*weight_dV
     p_fluid0(ix) = p_fluid0(ix)  + px*(1.0_num-cell_x)*weight_dV
     !p_fluid0(ix) = p_fluid0(ix)  + px*weight_dx
-    
+
     pressuret(ix) = pressuret(ix) + px*px*weight_dV
     forcet(ix) = forcet(ix) + weight_dV*mforce(1)
-    
+
   END SUBROUTINE assignweight_fluid
 
   SUBROUTINE fluideq_diag
@@ -1048,7 +1047,7 @@ CONTAINS
   END SUBROUTINE fluideq_diag
 
   ! Solve a simple fluid equation for moment update.
-  ! -lowest order Conservative finite volume 
+  ! -lowest order Conservative finite volume
   SUBROUTINE update_fluideq
     INTEGER :: ix, lr, ip
     REAL(num) :: flux(2), pflux(2), kterm
@@ -1072,14 +1071,14 @@ CONTAINS
        kterm = forcet(ix)
        p_fluid_next(ix)    = p_fluid(ix) &
             & + (pflux(1) - pflux(2))*dt_fluid/dx_fluid + kterm
-       !p_fluid_next(ix)    = p_fluid(ix)        
+       !p_fluid_next(ix)    = p_fluid(ix)
     END DO
     p_fluid = p_fluid_next
     dens_fluid = dens_fluid_next
   END SUBROUTINE update_fluideq
 
   SUBROUTINE setup_fluid
-    
+
     nx_fluid = nx
     dx_fluid = dx
     ALLOCATE(p_fluid(1:nx_fluid))
@@ -1101,9 +1100,9 @@ CONTAINS
     dt_fluid = dt
 
     CALL load_fluid
-   
+
   END SUBROUTINE setup_fluid
-    
+
   SUBROUTINE load_fluid
     REAL(num), DIMENSION(3) :: tl,dl,mforce
     REAL(num) :: p,part_weight,dens, dydz, volfac, x_pos
@@ -1112,7 +1111,7 @@ CONTAINS
     TYPE(particle), POINTER :: first_part
     TYPE(particle), POINTER :: dummy_part
     ALLOCATE(dummy_part)
-    
+
     gaussp = dx_fluid * (0.5 + 0.5 * (/-0.861136, -0.339981, 0.339981, 0.861136/) )
     gaussw = dx_fluid * 0.5 * (/ 0.347855,  0.652145, 0.652145, 0.347855/)
 
@@ -1121,9 +1120,9 @@ CONTAINS
 
     ! Pick first species, and first particle from that: assumed 1-species case
     ! and uniform mass, charge.
-    
+
     first_part => species_list%attached_list%head
-  
+
     do ix=1,nx
        do ig = 1,4
           x_pos = ix*dx_fluid + gaussp(ig)
@@ -1141,19 +1140,19 @@ CONTAINS
     end do
     dens_fluid = dens_fluid0
     p_fluid = p_fluid0
-    
+
     dens_fluid0= 0.0
     p_fluid0= 0.0
-   
+
   END SUBROUTINE load_fluid
-    
-    
+
+
   SUBROUTINE solve_fluid
     REAL(num) :: t, t_fin, vmax, xg
     INTEGER   :: it, ix, nt_fluid
 
     CALL setup_fluid
-    
+
     vmax=1.0
     DO ix=1,nx_fluid
        xg = ix*dx_fluid
@@ -1168,7 +1167,7 @@ CONTAINS
     t_fin = 10.0_num
     nt_fluid = FLOOR(t_fin/dt_fluid) + 1
     nt_fluid = 400
-    
+
     DO it = 1,nt_fluid
        t = it*dt_fluid
        DO ix=1,nx_fluid
@@ -1177,7 +1176,7 @@ CONTAINS
        END DO
        CALL update_fluideq
     end do
-    
+
     STOP
   END SUBROUTINE SOLVE_FLUID
 
@@ -1187,5 +1186,5 @@ CONTAINS
       pressuret   = 0.0
       forcet      = 0.0
   end subroutine initstep_fluid
-  
+
 END MODULE particles


### PR DESCRIPTION
Clean-up of particle push. Summary of changes:

 - Moved `push_particles_lorentz_split` out of the `push_particles` subroutine, in line with drift kinetic pushes.
 - Made the arguments for `push_particles_lorentz_split` and the drift kinetic routines the same.
 - Removed some duplicated declarations.
 - Formatting changes. Delete trailing whitespace.