### PR TITLE
Tom/current module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,12 +183,13 @@ PREPROFLAGS = $(DEFINES) $(D)_COMMIT='"$(COMMIT)"' $(D)_DATE=$(DATE) \
 FC_INFO := $(shell ${FC} --version 2>/dev/null \
     || ${FC} -V 2>&1 | grep '[a-zA-Z]' | head -n 1)
 
-SRCFILES = balance.F90 boundary.f90 calc_df.F90 custom_laser.f90 deck.f90 \
-  diagnostics.F90 epoch3d.F90 fields.f90 finish.f90 helper.F90 ic_module.f90 \
-  laser.f90 mpi_routines.F90 mpi_subtype_control.f90 particle_temperature.F90 \
-  particles.F90 partlist.F90 problem_setup.f90 random_generator.f90 \
-  redblack_module.f90 setup.F90 shared_data.F90 strings.f90 timer.f90 \
-  utilities.F90 version_data.F90 welcome.F90 deltaf_loader.F90
+SRCFILES = balance.F90 boundary.f90 calc_df.F90 current_deposition.F90 \
+  custom_laser.f90 deck.f90 diagnostics.F90 epoch3d.F90 fields.f90 finish.f90 \
+  helper.F90 ic_module.f90 laser.f90 mpi_routines.F90 mpi_subtype_control.f90 \
+  particle_temperature.F90 particles.F90 partlist.F90 problem_setup.f90 \
+  random_generator.f90 redblack_module.f90 setup.F90 shared_data.F90 \
+  strings.f90 timer.f90 utilities.F90 version_data.F90 welcome.F90 \
+  deltaf_loader.F90
 
 OBJFILES := $(SRCFILES:.f90=.o)
 OBJFILES := $(OBJFILES:.F90=.o)
@@ -254,6 +255,7 @@ balance.o: balance.F90 boundary.o redblack_module.o timer.o
 boundary.o: boundary.f90 laser.o mpi_subtype_control.o particle_temperature.o \
   partlist.o
 calc_df.o: calc_df.F90 shared_data.o
+current_deposition.o: current_deposition.F90 shared_data.o utilities.o
 custom_laser.o: custom_laser.f90 shared_data.o
 deck.o: deck.f90 shared_data.o timer.o fields.o
 diagnostics.o: diagnostics.F90 calc_df.o shared_data.o strings.o timer.o
@@ -270,7 +272,8 @@ mpi_routines.o: mpi_routines.F90 helper.o
 mpi_subtype_control.o: mpi_subtype_control.f90 shared_data.o
 particle_temperature.o: particle_temperature.F90 random_generator.o \
   shared_data.o
-particles.o: particles.F90 boundary.o deltaf_loader.o partlist.o utilities.o
+particles.o: particles.F90 boundary.o current_deposition.o \
+  deltaf_loader.o partlist.o utilities.o
 deltaf_loader.o: deltaf_loader.F90 shared_data.o
 partlist.o: partlist.F90 shared_data.o
 problem_setup.o: problem_setup.f90 fields.o ic_module.o shared_data.o \

--- a/src/current_deposition.F90
+++ b/src/current_deposition.F90
@@ -1,0 +1,241 @@
+MODULE current_deposition
+
+  USE shared_data
+  USE utilities
+
+  IMPLICIT NONE
+
+CONTAINS
+
+  ! Utility routine for calculating cell offsets and weights
+  ! at a position.
+  SUBROUTINE calc_stdata(pos,st)
+    TYPE(fields_eval_tmps), INTENT(INOUT) :: st
+    REAL(num), DIMENSION(3),   INTENT(INOUT) :: pos
+    INTEGER :: cell_x1, cell_y1, cell_z1
+    REAL(num) :: cell_x_r, cell_y_r, cell_z_r
+    REAL(num) :: part_x, part_y, part_z
+    REAL(num), DIMENSION(sf_min-1:sf_max+1) :: gx, gy, gz
+    REAL(num) :: cell_frac_x, cell_frac_y, cell_frac_z
+    REAL(num) :: cf2
+    REAL(num) :: idx, idy, idz
+
+    ! TODO - These should be private module variables
+    idx = 1.0_num / dx
+    idy = 1.0_num / dy
+    idz = 1.0_num / dz
+
+    part_x = pos(1) - x_grid_min_local
+    part_y = pos(2) - y_grid_min_local
+    part_z = pos(3) - z_grid_min_local
+
+    ! Grid cell position as a fraction.
+    cell_x_r = part_x * idx
+    cell_y_r = part_y * idy
+    cell_z_r = part_z * idz
+
+    ! Round cell position to nearest cell
+    cell_x1 = FLOOR(cell_x_r + 0.5_num)
+    ! Calculate fraction of cell between nearest cell boundary and particle
+    cell_frac_x = REAL(cell_x1, num) - cell_x_r
+    cell_x1 = cell_x1 + 1
+
+    cell_y1 = FLOOR(cell_y_r + 0.5_num)
+    cell_frac_y = REAL(cell_y1, num) - cell_y_r
+    cell_y1 = cell_y1 + 1
+
+    cell_z1 = FLOOR(cell_z_r + 0.5_num)
+    cell_frac_z = REAL(cell_z1, num) - cell_z_r
+    cell_z1 = cell_z1 + 1
+
+    ! Particle weight factors as described in the manual, page25
+    ! These weight grid properties onto particles
+    ! Also used to weight particle properties onto grid, used later
+    ! to calculate J
+    ! NOTE: These weights require an additional multiplication factor!
+    gx=0
+    gy=0
+    gz=0
+#include "bspline3/gx.inc"
+
+    !Temporary storage for current deposition.
+    st%gx = gx
+    st%gy = gy
+    st%gz = gz
+
+    st%cell_x1 = cell_x1
+    st%cell_y1 = cell_y1
+    st%cell_z1 = cell_z1
+
+  END SUBROUTINE calc_stdata
+
+
+
+  ! Do current deposition of particle moving along straight line
+  ! from pos0 to pos1, with chargeweight = weight*charge
+  SUBROUTINE current_deposition_pos(pos0, pos1, chargeweight, drift_switch)
+    REAL(num), DIMENSION(3), INTENT(INOUT) :: pos0,pos1
+    REAL(num), INTENT(IN) :: chargeweight
+    LOGICAL, INTENT(IN) :: drift_switch
+
+    TYPE(fields_eval_tmps)  :: st0
+
+    CALL calc_stdata(pos0,st0)
+    CALL current_deposition_store(st0, pos1, chargeweight, drift_switch)
+
+  END SUBROUTINE current_deposition_pos
+
+
+
+  ! Do current deposition, reusing some precalculated data (in st)
+  ! Particle has moved from pos0 (data stored in st) to pos
+  SUBROUTINE current_deposition_store(st,pos,chargeweight,drift_switch)
+    REAL(num), DIMENSION(3), INTENT(INOUT) :: pos
+    TYPE(fields_eval_tmps), INTENT(INOUT)  :: st
+    REAL(num), INTENT(IN) :: chargeweight
+    LOGICAL, INTENT(IN) :: drift_switch
+    REAL(num) :: idx, idy, idz
+    REAL(num) :: i_yz, i_xz, i_xy
+    REAL(num) :: cell_x_r, cell_y_r, cell_z_r
+    REAL(num) :: part_x, part_y, part_z
+    INTEGER :: cell_x3
+    INTEGER :: cell_y3
+    INTEGER :: cell_z3
+    INTEGER :: dcellx, dcelly, dcellz
+    REAL(num) :: cf2
+    ! Defined at the particle position - 0.5 grid cell in each direction
+    ! This is to deal with the grid stagger
+    REAL(num), DIMENSION(sf_min-1:sf_max+1) :: hx, hy, hz
+    ! J from a given particle, can be spread over up to 3 cells in
+    ! Each direction due to parabolic weighting. We allocate 4 or 5
+    ! Cells because the position of the particle at t = t+1.5dt is not
+    ! known until later. This part of the algorithm could probably be
+    ! Improved, but at the moment, this is just a straight copy of
+    ! The core of the PSC algorithm
+    INTEGER, PARAMETER :: sf0 = sf_min, sf1 = sf_max
+    REAL(num) :: jxh
+    REAL(num), DIMENSION(sf0-1:sf1+1) :: jyh
+    REAL(num), DIMENSION(sf0-1:sf1+1,sf0-1:sf1+1) :: jzh
+    REAL(num) :: fjx, fjy, fjz
+    ! The fraction of a cell between the particle position and the cell boundary
+    REAL(num) :: cell_frac_x, cell_frac_y, cell_frac_z
+    INTEGER :: ix, iy, iz, cx, cy, cz
+    REAL(num) :: gz_iz, hz_iz, hygz, hyhz, hzyfac1, hzyfac2, yzfac
+    ! Used by J update
+    INTEGER :: xmin, xmax, ymin, ymax, zmin, zmax
+    REAL(num) :: wx, wy, wz
+    REAL(num), PARAMETER :: third = (1.0_num / 3.0_num)
+    REAL(num), PARAMETER :: fac = (1.0_num / 24.0_num)**c_ndims
+    REAL(num) :: xfac1, xfac2, yfac1, yfac2, zfac1, zfac2
+
+    idx = 1.0_num / dx
+    idy = 1.0_num / dy
+    idz = 1.0_num / dz
+    !TODO - these remain constant throughout the simulation, and should only be calculated once
+    i_yz = idy * idz * fac
+    i_xz = idx * idz * fac
+    i_xy = idx * idy * fac
+
+    part_x = pos(1) - x_grid_min_local
+    part_y = pos(2) - y_grid_min_local
+    part_z = pos(3) - z_grid_min_local
+
+    cell_x_r = part_x * idx
+    cell_y_r = part_y * idy
+    cell_z_r = part_z * idz
+
+    cell_x3 = FLOOR(cell_x_r + 0.5_num)
+    cell_frac_x = REAL(cell_x3, num) - cell_x_r
+    cell_x3 = cell_x3 + 1
+
+    cell_y3 = FLOOR(cell_y_r + 0.5_num)
+    cell_frac_y = REAL(cell_y3, num) - cell_y_r
+    cell_y3 = cell_y3 + 1
+
+    cell_z3 = FLOOR(cell_z_r + 0.5_num)
+    cell_frac_z = REAL(cell_z3, num) - cell_z_r
+    cell_z3 = cell_z3 + 1
+
+    hx = 0.0_num
+    hy = 0.0_num
+    hz = 0.0_num
+
+    dcellx = cell_x3 - st%cell_x1
+    dcelly = cell_y3 - st%cell_y1
+    dcellz = cell_z3 - st%cell_z1
+    ! NOTE: These weights require an additional multiplication factor!
+#include "bspline3/hx_dcell.inc"
+
+    ! Now change Xi1* to be Xi1*-Xi0*. This makes the representation of
+    ! the current update much simpler
+    hx = hx - st%gx
+    hy = hy - st%gy
+    hz = hz - st%gz
+
+    ! Remember that due to CFL condition particle can never cross more
+    ! than one gridcell in one timestep
+
+    xmin = sf_min + (dcellx - 1) / 2
+    xmax = sf_max + (dcellx + 1) / 2
+
+    ymin = sf_min + (dcelly - 1) / 2
+    ymax = sf_max + (dcelly + 1) / 2
+
+    zmin = sf_min + (dcellz - 1) / 2
+    zmax = sf_max + (dcellz + 1) / 2
+
+    fjx = i_yz * chargeweight
+    fjy = i_xz * chargeweight
+    fjz = i_xy * chargeweight
+
+    jzh = 0.0_num
+    DO iz = zmin, zmax
+      cz = st%cell_z1 + iz
+      zfac1 = st%gz(iz) + 0.5_num * hz(iz)
+      zfac2 = third * hz(iz) + 0.5_num * st%gz(iz)
+
+      gz_iz = st%gz(iz)
+      hz_iz = hz(iz)
+
+      jyh = 0.0_num
+      DO iy = ymin, ymax
+        cy = st%cell_y1 + iy
+        yfac1 =         st%gy(iy) + 0.5_num * hy(iy)
+        yfac2 = third * hy(iy) + 0.5_num * st%gy(iy)
+
+        hygz = hy(iy) * gz_iz
+        hyhz = hy(iy) * hz_iz
+        yzfac = st%gy(iy) * zfac1 + hy(iy) * zfac2
+        hzyfac1 = hz_iz * yfac1
+        hzyfac2 = hz_iz * yfac2
+
+        jxh = 0.0_num
+        DO ix = xmin, xmax
+          cx = st%cell_x1 + ix
+          xfac1 = st%gx(ix) + 0.5_num * hx(ix)
+          xfac2 = third * hx(ix) + 0.5_num * st%gx(ix)
+
+          wx = hx(ix) * yzfac
+          wy = xfac1 * hygz + xfac2 * hyhz
+          wz = st%gx(ix) * hzyfac1 + hx(ix) * hzyfac2
+
+          ! This is the bit that actually solves d(rho)/dt = -div(J)
+          jxh = jxh - fjx * wx
+          jyh(ix) = jyh(ix) - fjy * wy
+          jzh(ix, iy) = jzh(ix, iy) - fjz * wz
+          IF (.NOT. drift_switch) THEN
+            jx(cx, cy, cz) = jx(cx, cy, cz) + jxh
+            jy(cx, cy, cz) = jy(cx, cy, cz) + jyh(ix)
+            jz(cx, cy, cz) = jz(cx, cy, cz) + jzh(ix, iy)
+          ELSE
+            jx_d(cx, cy, cz) = jx_d(cx, cy, cz) + jxh
+            jy_d(cx, cy, cz) = jy_d(cx, cy, cz) + jyh(ix)
+            jz_d(cx, cy, cz) = jz_d(cx, cy, cz) + jzh(ix, iy)
+          END IF
+        END DO
+      END DO
+    END DO
+
+  END SUBROUTINE current_deposition_store
+
+END MODULE current_deposition

--- a/src/current_deposition.F90
+++ b/src/current_deposition.F90
@@ -5,7 +5,12 @@ MODULE current_deposition
 
   IMPLICIT NONE
 
+  INTERFACE current_deposition_esirkepov
+    MODULE PROCEDURE current_deposition_esirkepov_pos, current_deposition_esirkepov_store
+  END INTERFACE current_deposition_esirkepov
+
   PRIVATE :: calc_stdata
+  PRIVATE :: current_deposition_esirkepov_pos, current_deposition_esirkepov_store
 
   REAL(num), PRIVATE :: idx, idy, idz
   REAL(num), PRIVATE :: i_yz, i_xz, i_xy
@@ -30,23 +35,24 @@ CONTAINS
 
   ! Do current deposition of particle moving along straight line
   ! from pos0 to pos1, with chargeweight = weight*charge
-  SUBROUTINE current_deposition_pos(pos0, pos1, chargeweight, drift_switch)
+  SUBROUTINE current_deposition_esirkepov_pos(pos0, pos1, chargeweight, drift_switch)
+
     REAL(num), DIMENSION(3), INTENT(INOUT) :: pos0,pos1
     REAL(num), INTENT(IN) :: chargeweight
     LOGICAL, INTENT(IN) :: drift_switch
-
     TYPE(fields_eval_tmps)  :: st0
 
     CALL calc_stdata(pos0,st0)
-    CALL current_deposition_store(st0, pos1, chargeweight, drift_switch)
+    CALL current_deposition_esirkepov_store(st0, pos1, chargeweight, drift_switch)
 
-  END SUBROUTINE current_deposition_pos
+  END SUBROUTINE current_deposition_esirkepov_pos
 
 
 
   ! Do current deposition, reusing some precalculated data (in st)
   ! Particle has moved from pos0 (data stored in st) to pos
-  SUBROUTINE current_deposition_store(st,pos,chargeweight,drift_switch)
+  SUBROUTINE current_deposition_esirkepov_store(st, pos, chargeweight, drift_switch)
+
     REAL(num), DIMENSION(3), INTENT(INOUT) :: pos
     TYPE(fields_eval_tmps), INTENT(INOUT)  :: st
     REAL(num), INTENT(IN) :: chargeweight
@@ -182,7 +188,7 @@ CONTAINS
       END DO
     END DO
 
-  END SUBROUTINE current_deposition_store
+  END SUBROUTINE current_deposition_esirkepov_store
 
 
 

--- a/src/current_deposition.F90
+++ b/src/current_deposition.F90
@@ -33,11 +33,23 @@ CONTAINS
 
 
 
-  ! Do current deposition of particle moving along straight line
-  ! from pos0 to pos1, with chargeweight = weight*charge
+  !****************************************************************************
+  !> \breif Calculate current deposition as particle moves from pos0 to pos1
+  !>
+  !> Uses the charge-conserving scheme of Esirkepov (see reference) to
+  !> calculate current due to macro-particle of total charge `chargeweight`.
+  !>
+  !> @param[in] pos0 3D (x, y, z) initial position of particle
+  !> @param[in] pos1 3D (x, y, z) final position of particle
+  !> @param[in] chargeweight Total charge of macro-particle
+  !> @param[in] drift_switch Control if current should be deposited in
+  !>            (jx, jy, jz) or (jx_d, jy_d, jz_d)
+  !>
+  !> Reference: (https://doi.org/10.1016/S0010-4655(00)00228-9)
+  !****************************************************************************
   SUBROUTINE current_deposition_esirkepov_pos(pos0, pos1, chargeweight, drift_switch)
 
-    REAL(num), DIMENSION(3), INTENT(INOUT) :: pos0,pos1
+    REAL(num), DIMENSION(3), INTENT(IN) :: pos0,pos1
     REAL(num), INTENT(IN) :: chargeweight
     LOGICAL, INTENT(IN) :: drift_switch
     TYPE(fields_eval_tmps)  :: st0
@@ -49,12 +61,27 @@ CONTAINS
 
 
 
-  ! Do current deposition, reusing some precalculated data (in st)
-  ! Particle has moved from pos0 (data stored in st) to pos
+  !****************************************************************************
+  !> \breif Calculate current deposition as particle moves from st to pos
+  !>
+  !> Uses the charge-conserving scheme of Esirkepov (see reference) to
+  !> calculate current due to macro-particle of total charge `chargeweight`.
+  !> Uses pre-computed weight-function information in place for initial
+  !> particle position
+  !>
+  !> @param[in] st TYPE(fields_eval_tmps) containing particle weight-function
+  !>               for initial position
+  !> @param[in] pos 3D (x, y, z) final position of particle
+  !> @param[in] chargeweight Total charge of macro-particle
+  !> @param[in] drift_switch Control if current should be deposited in
+  !>            (jx, jy, jz) or (jx_d, jy_d, jz_d)
+  !>
+  !> Reference: (https://doi.org/10.1016/S0010-4655(00)00228-9)
+  !****************************************************************************
   SUBROUTINE current_deposition_esirkepov_store(st, pos, chargeweight, drift_switch)
 
-    REAL(num), DIMENSION(3), INTENT(INOUT) :: pos
-    TYPE(fields_eval_tmps), INTENT(INOUT)  :: st
+    REAL(num), DIMENSION(3), INTENT(IN) :: pos
+    TYPE(fields_eval_tmps), INTENT(IN)  :: st
     REAL(num), INTENT(IN) :: chargeweight
     LOGICAL, INTENT(IN) :: drift_switch
     REAL(num) :: cell_x_r, cell_y_r, cell_z_r
@@ -196,7 +223,7 @@ CONTAINS
   ! at a position.
   SUBROUTINE calc_stdata(pos,st)
     TYPE(fields_eval_tmps), INTENT(INOUT) :: st
-    REAL(num), DIMENSION(3),   INTENT(INOUT) :: pos
+    REAL(num), DIMENSION(3), INTENT(IN) :: pos
     INTEGER :: cell_x1, cell_y1, cell_z1
     REAL(num) :: cell_x_r, cell_y_r, cell_z_r
     REAL(num) :: part_x, part_y, part_z

--- a/src/current_deposition.F90
+++ b/src/current_deposition.F90
@@ -5,6 +5,8 @@ MODULE current_deposition
 
   IMPLICIT NONE
 
+  PRIVATE :: calc_stdata
+
   REAL(num), PRIVATE :: idx, idy, idz
   REAL(num), PRIVATE :: i_yz, i_xz, i_xy
 
@@ -25,62 +27,6 @@ CONTAINS
   END SUBROUTINE setup_current_deposition
 
 
-
-  ! Utility routine for calculating cell offsets and weights
-  ! at a position.
-  SUBROUTINE calc_stdata(pos,st)
-    TYPE(fields_eval_tmps), INTENT(INOUT) :: st
-    REAL(num), DIMENSION(3),   INTENT(INOUT) :: pos
-    INTEGER :: cell_x1, cell_y1, cell_z1
-    REAL(num) :: cell_x_r, cell_y_r, cell_z_r
-    REAL(num) :: part_x, part_y, part_z
-    REAL(num), DIMENSION(sf_min-1:sf_max+1) :: gx, gy, gz
-    REAL(num) :: cell_frac_x, cell_frac_y, cell_frac_z
-    REAL(num) :: cf2
-
-    part_x = pos(1) - x_grid_min_local
-    part_y = pos(2) - y_grid_min_local
-    part_z = pos(3) - z_grid_min_local
-
-    ! Grid cell position as a fraction.
-    cell_x_r = part_x * idx
-    cell_y_r = part_y * idy
-    cell_z_r = part_z * idz
-
-    ! Round cell position to nearest cell
-    cell_x1 = FLOOR(cell_x_r + 0.5_num)
-    ! Calculate fraction of cell between nearest cell boundary and particle
-    cell_frac_x = REAL(cell_x1, num) - cell_x_r
-    cell_x1 = cell_x1 + 1
-
-    cell_y1 = FLOOR(cell_y_r + 0.5_num)
-    cell_frac_y = REAL(cell_y1, num) - cell_y_r
-    cell_y1 = cell_y1 + 1
-
-    cell_z1 = FLOOR(cell_z_r + 0.5_num)
-    cell_frac_z = REAL(cell_z1, num) - cell_z_r
-    cell_z1 = cell_z1 + 1
-
-    ! Particle weight factors as described in the manual, page25
-    ! These weight grid properties onto particles
-    ! Also used to weight particle properties onto grid, used later
-    ! to calculate J
-    ! NOTE: These weights require an additional multiplication factor!
-    gx=0
-    gy=0
-    gz=0
-#include "bspline3/gx.inc"
-
-    !Temporary storage for current deposition.
-    st%gx = gx
-    st%gy = gy
-    st%gz = gz
-
-    st%cell_x1 = cell_x1
-    st%cell_y1 = cell_y1
-    st%cell_z1 = cell_z1
-
-  END SUBROUTINE calc_stdata
 
   ! Do current deposition of particle moving along straight line
   ! from pos0 to pos1, with chargeweight = weight*charge
@@ -237,5 +183,63 @@ CONTAINS
     END DO
 
   END SUBROUTINE current_deposition_store
+
+
+
+  ! Utility routine for calculating cell offsets and weights
+  ! at a position.
+  SUBROUTINE calc_stdata(pos,st)
+    TYPE(fields_eval_tmps), INTENT(INOUT) :: st
+    REAL(num), DIMENSION(3),   INTENT(INOUT) :: pos
+    INTEGER :: cell_x1, cell_y1, cell_z1
+    REAL(num) :: cell_x_r, cell_y_r, cell_z_r
+    REAL(num) :: part_x, part_y, part_z
+    REAL(num), DIMENSION(sf_min-1:sf_max+1) :: gx, gy, gz
+    REAL(num) :: cell_frac_x, cell_frac_y, cell_frac_z
+    REAL(num) :: cf2
+
+    part_x = pos(1) - x_grid_min_local
+    part_y = pos(2) - y_grid_min_local
+    part_z = pos(3) - z_grid_min_local
+
+    ! Grid cell position as a fraction.
+    cell_x_r = part_x * idx
+    cell_y_r = part_y * idy
+    cell_z_r = part_z * idz
+
+    ! Round cell position to nearest cell
+    cell_x1 = FLOOR(cell_x_r + 0.5_num)
+    ! Calculate fraction of cell between nearest cell boundary and particle
+    cell_frac_x = REAL(cell_x1, num) - cell_x_r
+    cell_x1 = cell_x1 + 1
+
+    cell_y1 = FLOOR(cell_y_r + 0.5_num)
+    cell_frac_y = REAL(cell_y1, num) - cell_y_r
+    cell_y1 = cell_y1 + 1
+
+    cell_z1 = FLOOR(cell_z_r + 0.5_num)
+    cell_frac_z = REAL(cell_z1, num) - cell_z_r
+    cell_z1 = cell_z1 + 1
+
+    ! Particle weight factors as described in the manual, page25
+    ! These weight grid properties onto particles
+    ! Also used to weight particle properties onto grid, used later
+    ! to calculate J
+    ! NOTE: These weights require an additional multiplication factor!
+    gx=0
+    gy=0
+    gz=0
+#include "bspline3/gx.inc"
+
+    !Temporary storage for current deposition.
+    st%gx = gx
+    st%gy = gy
+    st%gz = gz
+
+    st%cell_x1 = cell_x1
+    st%cell_y1 = cell_y1
+    st%cell_z1 = cell_z1
+
+  END SUBROUTINE calc_stdata
 
 END MODULE current_deposition

--- a/src/current_deposition.F90
+++ b/src/current_deposition.F90
@@ -5,7 +5,26 @@ MODULE current_deposition
 
   IMPLICIT NONE
 
+  REAL(num), PRIVATE :: idx, idy, idz
+  REAL(num), PRIVATE :: i_yz, i_xz, i_xy
+
 CONTAINS
+
+  SUBROUTINE setup_current_deposition
+
+    REAL(num), PARAMETER :: fac = (1.0_num / 24.0_num)**c_ndims
+
+    idx = 1.0_num / dx
+    idy = 1.0_num / dy
+    idz = 1.0_num / dz
+
+    i_yz = idy * idz * fac
+    i_xz = idx * idz * fac
+    i_xy = idx * idy * fac
+
+  END SUBROUTINE setup_current_deposition
+
+
 
   ! Utility routine for calculating cell offsets and weights
   ! at a position.
@@ -18,12 +37,6 @@ CONTAINS
     REAL(num), DIMENSION(sf_min-1:sf_max+1) :: gx, gy, gz
     REAL(num) :: cell_frac_x, cell_frac_y, cell_frac_z
     REAL(num) :: cf2
-    REAL(num) :: idx, idy, idz
-
-    ! TODO - These should be private module variables
-    idx = 1.0_num / dx
-    idy = 1.0_num / dy
-    idz = 1.0_num / dz
 
     part_x = pos(1) - x_grid_min_local
     part_y = pos(2) - y_grid_min_local
@@ -69,8 +82,6 @@ CONTAINS
 
   END SUBROUTINE calc_stdata
 
-
-
   ! Do current deposition of particle moving along straight line
   ! from pos0 to pos1, with chargeweight = weight*charge
   SUBROUTINE current_deposition_pos(pos0, pos1, chargeweight, drift_switch)
@@ -94,8 +105,6 @@ CONTAINS
     TYPE(fields_eval_tmps), INTENT(INOUT)  :: st
     REAL(num), INTENT(IN) :: chargeweight
     LOGICAL, INTENT(IN) :: drift_switch
-    REAL(num) :: idx, idy, idz
-    REAL(num) :: i_yz, i_xz, i_xy
     REAL(num) :: cell_x_r, cell_y_r, cell_z_r
     REAL(num) :: part_x, part_y, part_z
     INTEGER :: cell_x3
@@ -125,16 +134,7 @@ CONTAINS
     INTEGER :: xmin, xmax, ymin, ymax, zmin, zmax
     REAL(num) :: wx, wy, wz
     REAL(num), PARAMETER :: third = (1.0_num / 3.0_num)
-    REAL(num), PARAMETER :: fac = (1.0_num / 24.0_num)**c_ndims
     REAL(num) :: xfac1, xfac2, yfac1, yfac2, zfac1, zfac2
-
-    idx = 1.0_num / dx
-    idy = 1.0_num / dy
-    idz = 1.0_num / dz
-    !TODO - these remain constant throughout the simulation, and should only be calculated once
-    i_yz = idy * idz * fac
-    i_xz = idx * idz * fac
-    i_xy = idx * idy * fac
 
     part_x = pos(1) - x_grid_min_local
     part_y = pos(2) - y_grid_min_local

--- a/src/current_deposition.F90
+++ b/src/current_deposition.F90
@@ -42,20 +42,21 @@ CONTAINS
   !> @param[in] pos0 3D (x, y, z) initial position of particle
   !> @param[in] pos1 3D (x, y, z) final position of particle
   !> @param[in] chargeweight Total charge of macro-particle
-  !> @param[in] drift_switch Control if current should be deposited in
-  !>            (jx, jy, jz) or (jx_d, jy_d, jz_d)
+  !> @param[in,out] jx Array to deposit x-component of current density
+  !> @param[in,out] jy Array to deposit y-component of current density
+  !> @param[in,out] jz Array to deposit z-component of current density
   !>
   !> Reference: (https://doi.org/10.1016/S0010-4655(00)00228-9)
   !****************************************************************************
-  SUBROUTINE current_deposition_esirkepov_pos(pos0, pos1, chargeweight, drift_switch)
+  SUBROUTINE current_deposition_esirkepov_pos(pos0, pos1, chargeweight, jx, jy, jz)
 
     REAL(num), DIMENSION(3), INTENT(IN) :: pos0,pos1
     REAL(num), INTENT(IN) :: chargeweight
-    LOGICAL, INTENT(IN) :: drift_switch
+    REAL(num), INTENT(INOUT), DIMENSION(1-jng:,1-jng:,1-jng:) :: jx, jy, jz
     TYPE(fields_eval_tmps)  :: st0
 
     CALL calc_stdata(pos0,st0)
-    CALL current_deposition_esirkepov_store(st0, pos1, chargeweight, drift_switch)
+    CALL current_deposition_esirkepov_store(st0, pos1, chargeweight, jx, jy, jz)
 
   END SUBROUTINE current_deposition_esirkepov_pos
 
@@ -73,17 +74,18 @@ CONTAINS
   !>               for initial position
   !> @param[in] pos 3D (x, y, z) final position of particle
   !> @param[in] chargeweight Total charge of macro-particle
-  !> @param[in] drift_switch Control if current should be deposited in
-  !>            (jx, jy, jz) or (jx_d, jy_d, jz_d)
+  !> @param[in,out] jx Array to deposit x-component of current density
+  !> @param[in,out] jy Array to deposit y-component of current density
+  !> @param[in,out] jz Array to deposit z-component of current density
   !>
   !> Reference: (https://doi.org/10.1016/S0010-4655(00)00228-9)
   !****************************************************************************
-  SUBROUTINE current_deposition_esirkepov_store(st, pos, chargeweight, drift_switch)
+  SUBROUTINE current_deposition_esirkepov_store(st, pos, chargeweight, jx, jy, jz)
 
     REAL(num), DIMENSION(3), INTENT(IN) :: pos
     TYPE(fields_eval_tmps), INTENT(IN)  :: st
     REAL(num), INTENT(IN) :: chargeweight
-    LOGICAL, INTENT(IN) :: drift_switch
+    REAL(num), INTENT(INOUT), DIMENSION(1-jng:,1-jng:,1-jng:) :: jx, jy, jz
     REAL(num) :: cell_x_r, cell_y_r, cell_z_r
     REAL(num) :: part_x, part_y, part_z
     INTEGER :: cell_x3
@@ -202,15 +204,10 @@ CONTAINS
           jxh = jxh - fjx * wx
           jyh(ix) = jyh(ix) - fjy * wy
           jzh(ix, iy) = jzh(ix, iy) - fjz * wz
-          IF (.NOT. drift_switch) THEN
-            jx(cx, cy, cz) = jx(cx, cy, cz) + jxh
-            jy(cx, cy, cz) = jy(cx, cy, cz) + jyh(ix)
-            jz(cx, cy, cz) = jz(cx, cy, cz) + jzh(ix, iy)
-          ELSE
-            jx_d(cx, cy, cz) = jx_d(cx, cy, cz) + jxh
-            jy_d(cx, cy, cz) = jy_d(cx, cy, cz) + jyh(ix)
-            jz_d(cx, cy, cz) = jz_d(cx, cy, cz) + jzh(ix, iy)
-          END IF
+
+          jx(cx, cy, cz) = jx(cx, cy, cz) + jxh
+          jy(cx, cy, cz) = jy(cx, cy, cz) + jyh(ix)
+          jz(cx, cy, cz) = jz(cx, cy, cz) + jzh(ix, iy)
         END DO
       END DO
     END DO

--- a/src/epoch3d.F90
+++ b/src/epoch3d.F90
@@ -119,6 +119,9 @@ PROGRAM pic
   CALL pat_mpi_open(patc_out_fn)
 #endif
 
+  ! Set-up particle push module
+  CALL setup_particle_push
+
   DO
     IF (timer_collect) THEN
       CALL timer_stop(c_timer_step)

--- a/src/particles.F90
+++ b/src/particles.F90
@@ -1,6 +1,7 @@
 MODULE particles
 
   USE boundary
+  USE current_deposition
   USE partlist
   USE deltaf_loader2, ONLY: params_local, params_local_all
   USE utilities
@@ -13,7 +14,6 @@ MODULE particles
 
   ! Some numerical factors needed for various particle-fields routines.
   REAL(num), PARAMETER :: fac = (1.0_num / 24.0_num)**c_ndims
-  REAL(num) :: i_yz, i_xz, i_xy ! can't store these as particle steps may vary
   REAL(num) :: idx, idy, idz
 
   ! For now, fluid equations for a single species
@@ -72,11 +72,6 @@ CONTAINS
     idx = 1.0_num / dx
     idy = 1.0_num / dy
     idz = 1.0_num / dz
-
-    ! Only used by current deposition
-    i_yz = idy * idz * fac
-    i_xz = idx * idz * fac
-    i_xy = idx * idy * fac
 
     next_species => species_list
     DO ispecies = 1, n_species
@@ -409,7 +404,7 @@ CONTAINS
          current%part_p(1:2)   = (/ part_u, part_mu /)
 
          !This is the current between step N+1/2 and N+3/2 so 2nd order at N+1
-         CALL current_deposition(pos_0,current%part_pos,(part_weight*part_q),.true.)
+         CALL current_deposition_pos(pos_0,current%part_pos,(part_weight*part_q),.true.)
 
          current => next
       ENDDO
@@ -471,216 +466,6 @@ CONTAINS
          + 4.0_num * cf2 * (1.5_num + cell_frac - cf2)
     array(offset+2) = (0.5_num - cell_frac)**4
   END SUBROUTINE hfun
-
-
-
-  ! Do current deposition of particle moving along straight line
-  ! from pos0 to pos1, with chargeweight = weight*charge
-  SUBROUTINE current_deposition(pos0,pos1,chargeweight,drift_switch)
-    REAL(num), DIMENSION(3), INTENT(INOUT) :: pos0,pos1
-    REAL(num), INTENT(IN) :: chargeweight
-    LOGICAL, INTENT(IN) :: drift_switch
-
-    TYPE(fields_eval_tmps)  :: st0
-
-    CALL calc_stdata(pos0,st0)
-    CALL current_deposition_store(st0,pos1,chargeweight,drift_switch)
-  END SUBROUTINE current_deposition
-
-  !Do current deposition, reusing some precalculated data (in st)
-  !Particle has moved from pos0 (data stored in st) to pos
-  SUBROUTINE current_deposition_store(st,pos,chargeweight,drift_switch)
-    REAL(num), DIMENSION(3), INTENT(INOUT) :: pos
-    TYPE(fields_eval_tmps), INTENT(INOUT)  :: st
-    REAL(num), INTENT(IN) :: chargeweight
-    LOGICAL, INTENT(IN) :: drift_switch
-
-    REAL(num) :: cell_x_r, cell_y_r, cell_z_r
-    REAL(num) :: part_x, part_y, part_z
-    INTEGER :: cell_x3
-    INTEGER :: cell_y3
-    INTEGER :: cell_z3
-    INTEGER :: dcellx, dcelly, dcellz
-    REAL(num) :: cf2
-    ! Defined at the particle position - 0.5 grid cell in each direction
-    ! This is to deal with the grid stagger
-    REAL(num), DIMENSION(sf_min-1:sf_max+1) :: hx, hy, hz
-    ! J from a given particle, can be spread over up to 3 cells in
-    ! Each direction due to parabolic weighting. We allocate 4 or 5
-    ! Cells because the position of the particle at t = t+1.5dt is not
-    ! known until later. This part of the algorithm could probably be
-    ! Improved, but at the moment, this is just a straight copy of
-    ! The core of the PSC algorithm
-    INTEGER, PARAMETER :: sf0 = sf_min, sf1 = sf_max
-    REAL(num) :: jxh
-    REAL(num), DIMENSION(sf0-1:sf1+1) :: jyh
-    REAL(num), DIMENSION(sf0-1:sf1+1,sf0-1:sf1+1) :: jzh
-    REAL(num) :: fjx, fjy, fjz
-    ! The fraction of a cell between the particle position and the cell boundary
-    REAL(num) :: cell_frac_x, cell_frac_y, cell_frac_z
-    INTEGER :: ix, iy, iz, cx, cy, cz
-    REAL(num) :: gz_iz, hz_iz, hygz, hyhz, hzyfac1, hzyfac2, yzfac
-    ! Used by J update
-    INTEGER :: xmin, xmax, ymin, ymax, zmin, zmax
-    REAL(num) :: wx, wy, wz
-    REAL(num), PARAMETER :: third=(1.0_num / 3.0_num)
-    REAL(num) :: xfac1, xfac2, yfac1, yfac2, zfac1, zfac2
-
-
-    part_x = pos(1) - x_grid_min_local
-    part_y = pos(2) - y_grid_min_local
-    part_z = pos(3) - z_grid_min_local
-
-    cell_x_r = part_x * idx
-    cell_y_r = part_y * idy
-    cell_z_r = part_z * idz
-
-    cell_x3 = FLOOR(cell_x_r + 0.5_num)
-    cell_frac_x = REAL(cell_x3, num) - cell_x_r
-    cell_x3 = cell_x3 + 1
-
-    cell_y3 = FLOOR(cell_y_r + 0.5_num)
-    cell_frac_y = REAL(cell_y3, num) - cell_y_r
-    cell_y3 = cell_y3 + 1
-
-    cell_z3 = FLOOR(cell_z_r + 0.5_num)
-    cell_frac_z = REAL(cell_z3, num) - cell_z_r
-    cell_z3 = cell_z3 + 1
-
-    hx = 0.0_num
-    hy = 0.0_num
-    hz = 0.0_num
-
-    dcellx = cell_x3 - st%cell_x1
-    dcelly = cell_y3 - st%cell_y1
-    dcellz = cell_z3 - st%cell_z1
-    ! NOTE: These weights require an additional multiplication factor!
-#include "bspline3/hx_dcell.inc"
-
-    ! Now change Xi1* to be Xi1*-Xi0*. This makes the representation of
-    ! the current update much simpler
-    hx = hx - st%gx
-    hy = hy - st%gy
-    hz = hz - st%gz
-
-    ! Remember that due to CFL condition particle can never cross more
-    ! than one gridcell in one timestep
-
-    xmin = sf_min + (dcellx - 1) / 2
-    xmax = sf_max + (dcellx + 1) / 2
-
-    ymin = sf_min + (dcelly - 1) / 2
-    ymax = sf_max + (dcelly + 1) / 2
-
-    zmin = sf_min + (dcellz - 1) / 2
-    zmax = sf_max + (dcellz + 1) / 2
-
-    fjx = i_yz * chargeweight
-    fjy = i_xz * chargeweight
-    fjz = i_xy * chargeweight
-
-    jzh = 0.0_num
-    DO iz = zmin, zmax
-       cz = st%cell_z1 + iz
-       zfac1 =         st%gz(iz) + 0.5_num * hz(iz)
-       zfac2 = third * hz(iz) + 0.5_num * st%gz(iz)
-
-       gz_iz = st%gz(iz)
-       hz_iz = hz(iz)
-
-       jyh = 0.0_num
-       DO iy = ymin, ymax
-          cy = st%cell_y1 + iy
-          yfac1 =         st%gy(iy) + 0.5_num * hy(iy)
-          yfac2 = third * hy(iy) + 0.5_num * st%gy(iy)
-
-          hygz = hy(iy) * gz_iz
-          hyhz = hy(iy) * hz_iz
-          yzfac = st%gy(iy) * zfac1 + hy(iy) * zfac2
-          hzyfac1 = hz_iz * yfac1
-          hzyfac2 = hz_iz * yfac2
-
-          jxh = 0.0_num
-          DO ix = xmin, xmax
-             cx = st%cell_x1 + ix
-             xfac1 =         st%gx(ix) + 0.5_num * hx(ix)
-             xfac2 = third * hx(ix) + 0.5_num * st%gx(ix)
-
-             wx = hx(ix) * yzfac
-             wy = xfac1 * hygz + xfac2 * hyhz
-             wz = st%gx(ix) * hzyfac1 + hx(ix) * hzyfac2
-
-             ! This is the bit that actually solves d(rho)/dt = -div(J)
-             jxh = jxh - fjx * wx
-             jyh(ix) = jyh(ix) - fjy * wy
-             jzh(ix, iy) = jzh(ix, iy) - fjz * wz
-             if (.NOT.drift_switch) then
-                jx(cx, cy, cz) = jx(cx, cy, cz) + jxh
-                jy(cx, cy, cz) = jy(cx, cy, cz) + jyh(ix)
-                jz(cx, cy, cz) = jz(cx, cy, cz) + jzh(ix, iy)
-             else
-                jx_d(cx, cy, cz) = jx_d(cx, cy, cz) + jxh
-                jy_d(cx, cy, cz) = jy_d(cx, cy, cz) + jyh(ix)
-                jz_d(cx, cy, cz) = jz_d(cx, cy, cz) + jzh(ix, iy)
-             end if
-          ENDDO
-       ENDDO
-    ENDDO
-  END SUBROUTINE current_deposition_store
-
-  ! Utility routine for calculating cell offsets and weights
-  ! at a position.
-  SUBROUTINE calc_stdata(pos,st)
-    TYPE(fields_eval_tmps), INTENT(INOUT) :: st
-    REAL(num), DIMENSION(3),   INTENT(INOUT) :: pos
-    INTEGER :: cell_x1, cell_y1, cell_z1
-    REAL(num) :: cell_x_r, cell_y_r, cell_z_r
-    REAL(num) :: part_x, part_y, part_z
-    REAL(num), DIMENSION(sf_min-1:sf_max+1) :: gx, gy, gz
-    REAL(num) :: cell_frac_x, cell_frac_y, cell_frac_z
-    REAL(num) :: cf2
-
-    part_x = pos(1) - x_grid_min_local
-    part_y = pos(2) - y_grid_min_local
-    part_z = pos(3) - z_grid_min_local
-
-    ! Grid cell position as a fraction.
-    cell_x_r = part_x * idx
-    cell_y_r = part_y * idy
-    cell_z_r = part_z * idz
-    ! Round cell position to nearest cell
-    cell_x1 = FLOOR(cell_x_r + 0.5_num)
-    ! Calculate fraction of cell between nearest cell boundary and particle
-    cell_frac_x = REAL(cell_x1, num) - cell_x_r
-    cell_x1 = cell_x1 + 1
-
-    cell_y1 = FLOOR(cell_y_r + 0.5_num)
-    cell_frac_y = REAL(cell_y1, num) - cell_y_r
-    cell_y1 = cell_y1 + 1
-
-    cell_z1 = FLOOR(cell_z_r + 0.5_num)
-    cell_frac_z = REAL(cell_z1, num) - cell_z_r
-    cell_z1 = cell_z1 + 1
-
-    ! Particle weight factors as described in the manual, page25
-    ! These weight grid properties onto particles
-    ! Also used to weight particle properties onto grid, used later
-    ! to calculate J
-    ! NOTE: These weights require an additional multiplication factor!
-    gx=0
-    gy=0
-    gz=0
-#include "bspline3/gx.inc"
-
-    !Temporary storage for current deposition.
-    st%gx = gx
-    st%gy = gy
-    st%gz = gz
-
-    st%cell_x1 = cell_x1
-    st%cell_y1 = cell_y1
-    st%cell_z1 = cell_z1
-  END SUBROUTINE calc_stdata
 
 
 

--- a/src/particles.F90
+++ b/src/particles.F90
@@ -264,7 +264,7 @@ CONTAINS
       ! Current deposition uses position at t+0.5dt and t+1.5dt, particle
       ! assumed to travel in direct line between these locations. Second order
       ! in time for evaluation of current at t+dt
-      CALL current_deposition_esirkepov(st_half, part_pos_t1p5, (part_weight*part_qfac), .FALSE.)
+      CALL current_deposition_esirkepov(st_half, part_pos_t1p5, (part_weight*part_qfac), jx, jy, jz)
 
       IF (species%solve_fluid) THEN
         part_v = (/part_ux, part_uy,part_uz/)
@@ -348,7 +348,7 @@ CONTAINS
          !Do current deposition using lowest order current. (current at t_{N+1})
          !Before we apply this current, E+B need to be stored in a temporary;
          !this is the lowest order current.
-         CALL current_deposition_esirkepov(st_0, pos_0, (part_weight*part_qfac), .TRUE.)
+         CALL current_deposition_esirkepov(st_0, pos_0, (part_weight*part_qfac), jx_d, jy_d, jz_d)
 
          current => next
       ENDDO
@@ -414,7 +414,7 @@ CONTAINS
          current%part_p(1:2)   = (/ part_u, part_mu /)
 
          !This is the current between step N+1/2 and N+3/2 so 2nd order at N+1
-         CALL current_deposition_esirkepov(pos_0, current%part_pos, (part_weight*part_q), .TRUE.)
+         CALL current_deposition_esirkepov(pos_0, current%part_pos, (part_weight*part_q), jx_d, jy_d, jz_d)
 
          current => next
       ENDDO

--- a/src/particles.F90
+++ b/src/particles.F90
@@ -11,10 +11,11 @@ MODULE particles
   PRIVATE
   PUBLIC :: push_particles, push_particles_2ndstep
   PUBLIC :: setup_fluid
+  PUBLIC :: setup_particle_push
 
   ! Some numerical factors needed for various particle-fields routines.
-  REAL(num), PARAMETER :: fac = (1.0_num / 24.0_num)**c_ndims
-  REAL(num) :: idx, idy, idz
+  REAL(num), PARAMETER, PRIVATE :: fac = (1.0_num / 24.0_num)**c_ndims
+  REAL(num), PRIVATE :: idx, idy, idz
 
   ! For now, fluid equations for a single species
   ! density is mass density, p_fluid is momentum density
@@ -25,6 +26,21 @@ MODULE particles
   INTEGER :: nx_fluid
 
 CONTAINS
+
+  ! Initialise unvarying module variables
+  SUBROUTINE setup_particle_push
+
+    ! Unvarying multiplication factors
+    idx = 1.0_num / dx
+    idy = 1.0_num / dy
+    idz = 1.0_num / dz
+
+    ! Now initialise current depositon module
+    CALL setup_current_deposition
+
+  END SUBROUTINE setup_particle_push
+
+
 
   SUBROUTINE push_particles_2ndstep
     TYPE(particle_species), POINTER :: species, next_species
@@ -67,11 +83,6 @@ CONTAINS
     jx_d = 0.0_num
     jy_d = 0.0_num
     jz_d = 0.0_num
-
-    ! Unvarying multiplication factors
-    idx = 1.0_num / dx
-    idy = 1.0_num / dy
-    idz = 1.0_num / dz
 
     next_species => species_list
     DO ispecies = 1, n_species
@@ -150,7 +161,7 @@ CONTAINS
     dto2 = dt / 2.0_num
     dtco2 = c * dto2
     dtfac = 0.5_num * dt * fac
-    
+
     idt = 1.0_num / dt_sub
     idt0 = 1.0_num / dt
     dto2 = dt_sub / 2.0_num

--- a/src/particles.F90
+++ b/src/particles.F90
@@ -264,7 +264,7 @@ CONTAINS
       ! Current deposition uses position at t+0.5dt and t+1.5dt, particle
       ! assumed to travel in direct line between these locations. Second order
       ! in time for evaluation of current at t+dt
-      CALL current_deposition_store(st_half,part_pos_t1p5,(part_weight*part_qfac),.false.)
+      CALL current_deposition_esirkepov(st_half, part_pos_t1p5, (part_weight*part_qfac), .FALSE.)
 
       IF (species%solve_fluid) THEN
         part_v = (/part_ux, part_uy,part_uz/)
@@ -348,8 +348,7 @@ CONTAINS
          !Do current deposition using lowest order current. (current at t_{N+1})
          !Before we apply this current, E+B need to be stored in a temporary;
          !this is the lowest order current.
-         CALL current_deposition_store(st_0,pos_0,(part_weight*part_qfac),.true.)
-
+         CALL current_deposition_esirkepov(st_0, pos_0, (part_weight*part_qfac), .TRUE.)
 
          current => next
       ENDDO
@@ -415,7 +414,7 @@ CONTAINS
          current%part_p(1:2)   = (/ part_u, part_mu /)
 
          !This is the current between step N+1/2 and N+3/2 so 2nd order at N+1
-         CALL current_deposition_pos(pos_0,current%part_pos,(part_weight*part_q),.true.)
+         CALL current_deposition_esirkepov(pos_0, current%part_pos, (part_weight*part_q), .TRUE.)
 
          current => next
       ENDDO


### PR DESCRIPTION
Move current routines into separate module, in preparation for implicit code, which uses a different current deposition routine.

Some additional code maintenance:

 - Create interface for Esirkepov current deposition routines.
 - Document Esirkepov routines, add reference.
 - Add initialisation routines for particle and current modules.

Currently WIP, as relies on #22 