### PR TITLE
Tom/simple current deposition

### DIFF
--- a/Data/example_input.deck
+++ b/Data/example_input.deck
@@ -24,4 +24,5 @@
   stdout_frequency = 10,
   particle_push_start_time = 0.0,
   nspecies = 0,
+  use_esirkepov = T,
 /

--- a/src/current_deposition.F90
+++ b/src/current_deposition.F90
@@ -45,11 +45,15 @@ CONTAINS
   !> @param[in] pos 3D (x, y, z) position of particle.
   !> @param[in] vel 3D (vx, vy, vz) velocity of particle.
   !> @param[in] chargeweight Total charge of macro-particle.
+  !> @param[in,out] jx Array to deposit x-component of current density
+  !> @param[in,out] jy Array to deposit y-component of current density
+  !> @param[in,out] jz Array to deposit z-component of current density
   !****************************************************************************
-  SUBROUTINE current_deposition_simple(pos, vel, chargeweight)
+  SUBROUTINE current_deposition_simple(pos, vel, chargeweight, jx, jy, jz)
 
     REAL(num), DIMENSION(3), INTENT(IN) :: pos, vel
     REAL(num), INTENT(IN) :: chargeweight
+    REAL(num), INTENT(INOUT), DIMENSION(1-jng:,1-jng:,1-jng:) :: jx, jy, jz
     REAL(num), DIMENSION(sf_min-1:sf_max+1) :: gx, gy, gz
     REAL(num), DIMENSION(sf_min-1:sf_max+1) :: hx, hy, hz
     REAL(num) :: part_x, part_y, part_z

--- a/src/deck/deck.f90
+++ b/src/deck/deck.f90
@@ -21,7 +21,7 @@ CONTAINS
          allow_cpu_reduce, timer_collect, use_balance, use_random_seed, &
          npart_global, nsteps, t_end, dt_multiplier, dlb_threshold, &
          stdout_frequency, particle_push_start_time, n_species, &
-         fixed_fields, global_substeps
+         fixed_fields, global_substeps, use_esirkepov
 
     IF (first) THEN
       ! Set the default problem here

--- a/src/particles.F90
+++ b/src/particles.F90
@@ -267,8 +267,8 @@ CONTAINS
         ! in time for evaluation of current at t+dt
         CALL current_deposition_esirkepov(st_half, part_pos_t1p5, (part_weight*part_qfac), jx, jy, jz)
       ELSE
-        ! TODO
-        STOP
+        part_v = (/part_ux, part_uy, part_uz/) * c / gamma
+        CALL current_deposition_simple(current%part_pos, part_v, part_weight * part_q)
       END IF
 
       IF (species%solve_fluid) THEN

--- a/src/particles.F90
+++ b/src/particles.F90
@@ -256,15 +256,20 @@ CONTAINS
         weight_back = current%pvol * f0(species, current, current%mass)
       END IF
 
-      ! Now advance to t+1.5dt to calculate current. This is detailed in
-      ! the manual between pages 37 and 41. The version coded up looks
-      ! completely different to that in the manual, but is equivalent.
-      ! Use t+1.5 dt so that can update J to t+dt at 2nd order
-      part_pos_t1p5 = current%part_pos + (/ delta_x, delta_y, delta_z /)
-      ! Current deposition uses position at t+0.5dt and t+1.5dt, particle
-      ! assumed to travel in direct line between these locations. Second order
-      ! in time for evaluation of current at t+dt
-      CALL current_deposition_esirkepov(st_half, part_pos_t1p5, (part_weight*part_qfac), jx, jy, jz)
+      IF (use_esirkepov) THEN
+        ! Now advance to t+1.5dt to calculate current. This is detailed in
+        ! the manual between pages 37 and 41. The version coded up looks
+        ! completely different to that in the manual, but is equivalent.
+        ! Use t+1.5 dt so that can update J to t+dt at 2nd order
+        part_pos_t1p5 = current%part_pos + (/ delta_x, delta_y, delta_z /)
+        ! Current deposition uses position at t+0.5dt and t+1.5dt, particle
+        ! assumed to travel in direct line between these locations. Second order
+        ! in time for evaluation of current at t+dt
+        CALL current_deposition_esirkepov(st_half, part_pos_t1p5, (part_weight*part_qfac), jx, jy, jz)
+      ELSE
+        ! TODO
+        STOP
+      END IF
 
       IF (species%solve_fluid) THEN
         part_v = (/part_ux, part_uy,part_uz/)

--- a/src/particles.F90
+++ b/src/particles.F90
@@ -353,7 +353,11 @@ CONTAINS
          !Do current deposition using lowest order current. (current at t_{N+1})
          !Before we apply this current, E+B need to be stored in a temporary;
          !this is the lowest order current.
-         CALL current_deposition_esirkepov(st_0, pos_0, (part_weight*part_qfac), jx_d, jy_d, jz_d)
+         IF (use_esirkepov) THEN
+           CALL current_deposition_esirkepov(st_0, pos_0, (part_weight*part_qfac), jx_d, jy_d, jz_d)
+         ELSE
+           CALL current_deposition_simple(pos_h, dRdt, part_weight * part_q, jx_d, jy_d, jz_d)
+         END IF
 
          current => next
       ENDDO
@@ -419,7 +423,12 @@ CONTAINS
          current%part_p(1:2)   = (/ part_u, part_mu /)
 
          !This is the current between step N+1/2 and N+3/2 so 2nd order at N+1
-         CALL current_deposition_esirkepov(pos_0, current%part_pos, (part_weight*part_q), jx_d, jy_d, jz_d)
+         IF (use_esirkepov) THEN
+           CALL current_deposition_esirkepov(pos_0, current%part_pos, (part_weight*part_q), jx_d, jy_d, jz_d)
+         ELSE
+           pos_h = current%part_pos - dRdt_1 * 0.5_num * dt
+           CALL current_deposition_simple(pos_h, dRdt_1, part_weight * part_q, jx_d, jy_d, jz_d)
+         END IF
 
          current => next
       ENDDO

--- a/src/particles.F90
+++ b/src/particles.F90
@@ -268,7 +268,7 @@ CONTAINS
         CALL current_deposition_esirkepov(st_half, part_pos_t1p5, (part_weight*part_qfac), jx, jy, jz)
       ELSE
         part_v = (/part_ux, part_uy, part_uz/) * c / gamma
-        CALL current_deposition_simple(current%part_pos, part_v, part_weight * part_q)
+        CALL current_deposition_simple(current%part_pos, part_v, part_weight * part_q, jx, jy, jz)
       END IF
 
       IF (species%solve_fluid) THEN

--- a/src/shared_data.F90
+++ b/src/shared_data.F90
@@ -305,6 +305,9 @@ MODULE shared_data
 
   LOGICAL :: use_random_seed = .FALSE.
 
+  ! Control use of Esirkepov (charge conserving) current deposition
+  LOGICAL :: use_esirkepov = .TRUE.
+
   REAL(num) :: dt, t_end, time, dt_multiplier, dt_laser, dt_plasma_frequency
   REAL(num) :: cfl
   ! x_min is the left-hand edge of the simulation domain as specified in


### PR DESCRIPTION
Add naive (non charge-conserving) current deposition routine for implicit solver.

Note, I don't envisage the option `use_esirkepov = F` to have much use outside of the implicit solver, but I've added it as an option temporarily, for testing purposes. I haven't ported the method to the drift kinetic push because: (1) I don't quite know what current is what, and (2) I don't see why you'd want to use it.

The simple current deposition gets a comparable growth rate for the two stream instability as the Esirkepov method.

Simple:

![two_stream_simple](https://user-images.githubusercontent.com/50208076/121229880-6e803180-c886-11eb-826d-831f2ea8bfc0.png)


Esirkepov:

![two_stream](https://user-images.githubusercontent.com/50208076/121229849-658f6000-c886-11eb-8d56-c6d33f7ebde4.png)

WIP, as depends on #22 and #23 