### PR TITLE
Fix default value of flip_dir in processor_summation_bcs.

### DIFF
--- a/src/boundary.f90
+++ b/src/boundary.f90
@@ -669,8 +669,9 @@ CONTAINS
     INTEGER, INTENT(IN), OPTIONAL :: flip_direction
     REAL(num), DIMENSION(:,:,:), ALLOCATABLE :: temp
     INTEGER, DIMENSION(c_ndims) :: sizes, subsizes, starts
-    INTEGER :: subarray, nn, sz, i, flip_dir = 0
+    INTEGER :: subarray, nn, sz, i, flip_dir
 
+    flip_dir = 0
     IF (PRESENT(flip_direction)) flip_dir = flip_direction
 
     sizes(1) = nx + 2 * ng


### PR DESCRIPTION
Previously the implied SAVE state meant that the default value
of flip_dir could change call-to-call.

Note this bug would only cause problems for non-periodic boundary conditions.