### PR TITLE
Use custom docker image

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@
 
 name: CI
 
-# Controls when the action will run. 
+# Controls when the action will run.
 on:
   # Triggers the workflow on push (all branches) or pull request (only main)
   push:
@@ -21,19 +21,16 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
+    container: docker://tomgoffrey/minepoch_deps:latest
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-  
+
       # Build minepoch
       - name: Build
         run: |
-          sudo apt-get update -y
-          sudo apt-get install -y mpich
-          pip3 install numpy
-          pip3 install scipy
-          pip3 install matplotlib
           make COMPILER=gfortran
 
       - name: Test


### PR DESCRIPTION
The implicit solver will require Trilinos to run, therefore a docker image with Trilinos pre-installed will be needed for the CI.

I've added one on Docker Hub (https://hub.docker.com/repository/docker/tomgoffrey/minepoch_deps/general). This change switches the CI testing to use it.