### PR TITLE
Tom/em solver test

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,6 +54,13 @@ jobs:
           export PYTHONPATH=$PYTHONPATH:$(pwd)
           python3 minepoch_py/test.py --disable_plots
 
+      - name: Test-EM-Wave
+        run: |
+          cp Data/em_wave.deck Data/input.deck
+          mpirun -np 2 ./bin/epoch3d
+          export PYTHONPATH=$PYTHONPATH:$(pwd)
+          python3 minepoch_py/energy.py --disable_plots --energy_conservation=2e-11
+
       - name: Unit-Tests
         run: |
           cd src/unit_tests/field_evaluation

--- a/Data/em_wave.deck
+++ b/Data/em_wave.deck
@@ -1,0 +1,15 @@
+&CONTROL
+  problem = 'em_wave',
+  stdout_frequency = 25,
+  n_field_probes = 2,
+/
+
+! List of positions to output field time-histories
+! Two files will be produced:
+! 1. ix=10, iy=2, iz=2
+! 2. ix=180, iy=2, iz=2
+&FIELD_PROBE_POSITIONS
+  x_probes = 10, 180,
+  y_probes = 2, 2,
+  z_probes = 2, 2,
+/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ A number of example input decks are included with the code:
     substepping enabled.
  - `Data/one_stream.deck`: A 1D force-free problem illustrating the use of low-noise control-variates.
  - `Data/drift_kinetic.deck`: An demonstration of the use of drift-kinetics in a quasi-1D setting.
+ - `Data/em_wave.deck`: A simple electromagnetic wave set-up in a vacuum. Also demonstrates use
+    of the field probe diagnostic.
  
 To run one of these problems the input deck must be copied to the correct location before running
 minepoch, for example:

--- a/minepoch_py/energy.py
+++ b/minepoch_py/energy.py
@@ -1,5 +1,31 @@
+#!/usr/bin/env python3
+import sys
+import argparse
 import matplotlib.pyplot as plt
 import numpy as np
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description="""Energy conservation analysis for minEPOCH
+        """,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    group = parser.add_argument_group("Tolerances")
+
+    group.add_argument(
+        "--energy_conservation",
+        default=1e-4,
+        type=float,
+        help="Allowed fractional error in energy conservation",
+        nargs="?",
+    )
+
+    parser.add_argument("--disable_plots", help="Disable plot generation",
+                        action="store_true")
+
+    return parser.parse_args()
 
 
 def get_energies(fname):
@@ -21,7 +47,8 @@ def get_energies(fname):
     return times, particle_energies, field_energies
 
 
-def plot_field_energy(fname, xscale=1.0, dbg=False, ylog=False, xlog=False, **kwargs):
+def plot_field_energy(fname, xscale=1.0, dbg=False, ylog=False, xlog=False,
+                      **kwargs):
     # Read energies from file. Ignore particle energy
     times, _, energies = get_energies(fname)
 
@@ -71,3 +98,12 @@ def energy_check(fname='Data/output.dat', tolerance=None, label=None,
         return 0
 
     return None
+
+
+if __name__ == "__main__":
+    # Parse arguments
+    options = parse_arguments()
+    # Run error analysis
+    sys.exit(energy_check(tolerance=options.energy_conservation,
+                          plot=not options.disable_plots,
+                          savefig=True))

--- a/src/deck/deck.f90
+++ b/src/deck/deck.f90
@@ -103,6 +103,13 @@ CONTAINS
       END IF
 
       DEALLOCATE(lines)
+
+      ! TODO make this deck configurable
+      n_field_probes = 1
+      ALLOCATE(field_probes(3, n_field_probes))
+      field_probes(1, 1) = 10
+      field_probes(2, 1) = 2
+      field_probes(3, 1) = 2
     END IF
 
   END SUBROUTINE read_deck

--- a/src/housekeeping/finish.f90
+++ b/src/housekeeping/finish.f90
@@ -66,6 +66,8 @@ CONTAINS
       DEALLOCATE(iolist, STAT=stat)
     ENDDO
 
+    DEALLOCATE(field_probes)
+
     CALL deallocate_lasers
 
     CALL MPI_COMM_FREE(comm, errcode)

--- a/src/housekeeping/finish.f90
+++ b/src/housekeeping/finish.f90
@@ -66,7 +66,7 @@ CONTAINS
       DEALLOCATE(iolist, STAT=stat)
     ENDDO
 
-    DEALLOCATE(field_probes)
+    IF (ALLOCATED(field_probes)) DEALLOCATE(field_probes)
 
     CALL deallocate_lasers
 

--- a/src/housekeeping/problem_setup.f90
+++ b/src/housekeeping/problem_setup.f90
@@ -78,16 +78,18 @@ CONTAINS
     particle_push_start_time = 0.0_num
     n_species = 0
     fixed_fields = .FALSE.
-    
+
   END SUBROUTINE control_initialise
 
 
 
   SUBROUTINE fields_initialise(problem)
-    INTEGER :: i,j,k
-    REAL(num) :: xp
 
     CHARACTER(LEN=c_max_string_length), INTENT(IN) :: problem
+    INTEGER :: i,j,k
+    REAL(num) :: xp
+    REAL(num), PARAMETER :: em_wave_mag = 1.0_num
+
 
     ! Could include problem specific fields here.
     ! Default to zero
@@ -98,24 +100,25 @@ CONTAINS
     by = 0.0_num
     bz = 0.0_num
     SELECT CASE (TRIM(problem))
+
     CASE ('one_stream')
        IF (.false.) THEN
           bx = 1.0_num
           ey = 1.0_num
-          
+
           !To do this right, need to get the offsets to the grid positions.
           do i=1-ng,nx+ng
              do j=1-ng,ny+ng
                 do k=1-ng,nz+ng
-                   !Correct offset for bz, is there a variable 
+                   !Correct offset for bz, is there a variable
                    ! storing offset per field/direction?
                    xp = x_grid_min_local+(i-0.5_num)*dx
                    bz(i,j,k) = cos(xp)
-                   
                 end do
              end do
           end do
        END IF
+
     CASE ('drift_kin_default')
        ex = 0.0_num
        ey = 0.0_num
@@ -123,8 +126,24 @@ CONTAINS
        bx = 0.0_num
        by = 0.0_num
        bz = 1.0_num
+
+    CASE ('em_wave')
+      ex = 0.0_num
+      ez = 0.0_num
+      bx = 0.0_num
+      by = 0.0_num
+
+      DO i = 1-ng, nx+ng
+        xp = x_grid_min_local + x(i)
+        ey(i,:,:) = em_wave_mag * COS(xp)
+        xp = xp + 0.5_num * dx
+        bz(i,:,:) = em_wave_mag * COS(xp) / c
+      END DO
+
     CASE default
+
     END SELECT
+
   END SUBROUTINE fields_initialise
 
 

--- a/src/housekeeping/problem_setup.f90
+++ b/src/housekeeping/problem_setup.f90
@@ -88,7 +88,7 @@ CONTAINS
     CHARACTER(LEN=c_max_string_length), INTENT(IN) :: problem
     INTEGER :: i,j,k
     REAL(num) :: xp
-    REAL(num), PARAMETER :: em_wave_mag = 1.0_num
+    REAL(num), PARAMETER :: em_wave_mag = 1e6_num
 
 
     ! Could include problem specific fields here.

--- a/src/housekeeping/problem_setup.f90
+++ b/src/housekeeping/problem_setup.f90
@@ -134,7 +134,7 @@ CONTAINS
       by = 0.0_num
 
       DO i = 1-ng, nx+ng
-        xp = x_grid_min_local + x(i)
+        xp = x(i)
         ey(i,:,:) = em_wave_mag * COS(xp)
         xp = xp + 0.5_num * dx
         bz(i,:,:) = em_wave_mag * COS(xp) / c

--- a/src/io/calc_df.F90
+++ b/src/io/calc_df.F90
@@ -19,8 +19,6 @@ CONTAINS
 
     particle_energy = 0.0_num
 
-    IF (n_species < 1) RETURN
-
     ! Sum over all particles to calculate total kinetic energy
     next_species => species_list
     DO ispecies = 1, n_species

--- a/src/particles.F90
+++ b/src/particles.F90
@@ -692,6 +692,7 @@ CONTAINS
 
   SUBROUTINE setup_fluid
 
+    IF (n_species <= 0) RETURN
     nx_fluid = nx
     dx_fluid = dx
     ALLOCATE(p_fluid(1:nx_fluid))

--- a/src/shared_data.F90
+++ b/src/shared_data.F90
@@ -399,6 +399,9 @@ MODULE shared_data
   REAL(num) :: walltime_start, real_walltime_start
   INTEGER :: stdout_frequency
 
+  INTEGER :: n_field_probes = 0
+  INTEGER, DIMENSION(:,:), ALLOCATABLE :: field_probes
+
   LOGICAL, DIMENSION(c_dir_x:c_dir_z,0:c_stagger_max) :: stagger
   INTEGER(i8) :: push_per_field = 5
 

--- a/src/user_interaction/ic_module.f90
+++ b/src/user_interaction/ic_module.f90
@@ -31,6 +31,8 @@ CONTAINS
       CALL one_stream_setup(deck_state)
     CASE('drift_kin_default')
       CALL dk_setup(deck_state)
+    CASE('em_wave')
+      CALL em_wave_setup(deck_state)
     CASE default
       PRINT*, 'Unrecognised set-up: ', TRIM(problem)
       CALL MPI_ABORT(MPI_COMM_WORLD, c_err_setup, errcode)
@@ -149,6 +151,37 @@ CONTAINS
     current_species%temp(:,:,:,1) = temp_x
 
   END SUBROUTINE two_stream_setup
+
+
+
+
+
+  SUBROUTINE em_wave_setup(deck_state)
+
+    INTEGER, INTENT(IN) :: deck_state
+
+    IF (deck_state == c_ds_first) THEN
+      ! Set control variables here
+      nx_global = 64
+      ny_global = 4
+      nz_global = 4
+      x_min = 0.0_num
+      x_max = 2.0_num * pi
+      y_min = x_min
+      ! Could do (x_max * ny_global) / nx_global, but be wary of compilers
+      ! which don't obey precedence implied by parentheses by default
+      ! (e.g. Intel)
+      y_max = x_max * REAL(ny_global, num) / REAL(nx_global, num)
+      z_min = x_min
+      z_max = x_max * REAL(nz_global, num) / REAL(nx_global, num)
+
+      t_end = 2.0_num * pi / c
+      RETURN
+    END IF
+
+    ! No particles - nothing more to do
+
+  END SUBROUTINE em_wave_setup
 
 
 

--- a/src/user_interaction/ic_module.f90
+++ b/src/user_interaction/ic_module.f90
@@ -162,7 +162,7 @@ CONTAINS
 
     IF (deck_state == c_ds_first) THEN
       ! Set control variables here
-      nx_global = 64
+      nx_global = 256
       ny_global = 4
       nz_global = 4
       x_min = 0.0_num
@@ -175,7 +175,7 @@ CONTAINS
       z_min = x_min
       z_max = x_max * REAL(nz_global, num) / REAL(nx_global, num)
 
-      t_end = 2.0_num * pi / c
+      t_end = 20.0_num * pi / c
       RETURN
     END IF
 


### PR DESCRIPTION
Adds a new EM wave (in vacuum) set-up, for testing EM solver(s).

Also adds simple diagnostic which allows user to request time histories of fields at a fixed cell index.

Relies on #31, which should be merged first.

I do plan to add the field probes to the CI testing, but that requires a re-organisation of how the current tests are run, so will be addressed in a future PR.

Edit: The current set-up is only included in the CI tests via an energy conservation check.