### PR TITLE
Tom/cmake

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
+  # This workflow contains two jobs called "build" and "build-cmake"
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
@@ -74,3 +74,31 @@ jobs:
           make COMPILER=gfortran
           ./bin/particle_momentum_test
           python3 check_test.py
+          
+  build-cmake:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    container: docker://tomgoffrey/minepoch_deps:latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Build minepoch
+      - name: Build
+        run: |
+          mkdir build && cd build
+          cmake ..
+          make
+          make install
+          cd .. && rm -rf build
+
+      - name: Test
+        run: |
+          cp Data/two_stream.deck Data/input.deck
+          ./bin/epoch3d
+          export PYTHONPATH=$PYTHONPATH:$(pwd)
+          python3 minepoch_py/test.py --disable_plots
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,92 @@
+# CMake file for minEPOCH
+
+cmake_minimum_required (VERSION 3.1)
+project (minepoch)
+enable_language (Fortran)
+
+if (NOT CMAKE_BUILD_TYPE)
+  set (CMAKE_BUILD_TYPE RELEASE CACHE STRING
+      "Choose the type of build, options are: None Debug Release."
+      FORCE)
+endif (NOT CMAKE_BUILD_TYPE)
+
+# default installation
+get_filename_component (default_prefix ${CMAKE_SOURCE_DIR} ABSOLUTE)
+set (CMAKE_INSTALL_PREFIX ${default_prefix} CACHE STRING
+      "Choose the installation directory; by default it installs in the minepoch directory."
+      FORCE)
+
+# FFLAGS depend on the compiler
+get_filename_component (Fortran_COMPILER_NAME ${CMAKE_Fortran_COMPILER} NAME)
+
+if (Fortran_COMPILER_NAME MATCHES "gfortran.*")
+  # GNU
+  set (CMAKE_Fortran_FLAGS_RELEASE "-O3")
+  set (CMAKE_Fortran_FLAGS_DEBUG   "-O0 -g -Wall -Wextra -pedantic -fbounds-check -ffpe-trap=invalid,zero,overflow -Wno-unused-parameter -ffpe-trap=underflow,denormal")
+elseif (Fortran_COMPILER_NAME MATCHES "ifort.*")
+  # Intel
+  set (CMAKE_Fortran_FLAGS_RELEASE "-O3")
+  set (CMAKE_Fortran_FLAGS_DEBUG   "-O0 -fpe0 -nothreads -traceback -fltconsistency -C -g -heap-arrays 64 -warn -fpic")
+else (Fortran_COMPILER_NAME MATCHES "gfortran.*")
+  message ("CMAKE_Fortran_COMPILER full path: " ${CMAKE_Fortran_COMPILER})
+  message ("Fortran compiler: " ${Fortran_COMPILER_NAME})
+  message ("No optimized Fortran compiler flags are known, trying -O3")
+  set (CMAKE_Fortran_FLAGS_RELEASE "-O3")
+  set (CMAKE_Fortran_FLAGS_DEBUG   "-O0 -g")
+endif (Fortran_COMPILER_NAME MATCHES "gfortran.*")
+
+# Add src files
+file(GLOB all_SRCS
+        "src/*.f90"
+	"src/*.F90"
+	"src/deck/*.f90"
+	"src/deck/*.F90"
+	"src/housekeeping/*.f90"
+	"src/housekeeping/*.F90"
+	"src/include/*.inc"
+	"src/include/bspline3/*.inc"
+	"src/io/*.f90"
+	"src/io/*.F90"
+	"src/user_interaction/*.f90"
+	"src/user_interaction/*.F90"
+        )
+
+# Set module file location
+set(CMAKE_Fortran_MODULE_DIRECTORY obj)
+
+# External dependencies
+find_package(MPI REQUIRED)
+
+include_directories(${MPI_INCLUDE_PATH})
+
+include_directories("src/include")
+
+# Add executable
+add_executable("epoch3d" ${all_SRCS})
+
+# Add precompiler flags
+add_compile_definitions(DELTAF_METHOD PARTICLE_SHAPE_BSPLINE3)
+
+# Date flag
+string(TIMESTAMP DATE "%Y%m%d")
+add_compile_definitions(_DATE=${DATE})
+
+# Machine flag
+execute_process(COMMAND uname -n OUTPUT_VARIABLE MACHINE)
+string(REGEX REPLACE "\n$" "" MACHINE "${MACHINE}") 
+add_compile_definitions(_MACHINE="${MACHINE}")
+
+# COMMIT flag
+execute_process(COMMAND sh src/gen_commit_string.sh WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+execute_process(COMMAND cat src/COMMIT OUTPUT_VARIABLE COMMIT WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/)
+string(REGEX REPLACE "\n$" "" COMMIT "${COMMIT}")
+string(SUBSTRING "${COMMIT}" 7 -1 COMMIT)
+add_compile_definitions(_COMMIT="${COMMIT}")
+
+# Add MPI
+target_link_libraries(epoch3d ${MPI_Fortran_LIBRARIES})
+set_target_properties(epoch3d PROPERTIES LINK_FLAGS ${MPI_Fortran_LINK_FLAGS})
+#set_target_properties(epoch3d PROPERTIES LINK_FLAGS ${MPI_LINK_FLAGS})
+
+# install executables and scripts
+install (TARGETS epoch3d DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ treated.
 
 ## Compiling the code
 
+### Make
+
 The code can be compiled using make, and an appropriately set compiler variable, for example:
 
 ```
@@ -18,6 +20,21 @@ $ make COMPILER=gfortran
 The requirements are minimal, only a Fortran compiler and MPI are required to compile and run
 the code. The code is routinely run on both Linux and OS X, and tested with gfortran, but
 other compilers (e.g. `make COMPILER=intel`) ought to work.
+
+### CMake
+
+Alternatively minepoch can be compiled using cmake. For example:
+
+```
+$ mkdir build && cd build
+$ cmake ..
+$ make
+$ make install
+```
+
+By default minepoch will be installed to the `bin` subdirectory of the minepoch directory.
+
+After installation the temporary `build` directory may be deleted.
 
 ## Running the code
 


### PR DESCRIPTION
Newer versions of Trilinos (which is needed for the implicit solver) only support CMake driven builds, so this PR adds a CMake build for minepoch.